### PR TITLE
test: calendar-day arithmetic in every _rel helper — kill the DST span flake

### DIFF
--- a/src/packages/flutter-app/test/home_travels_band_test.dart
+++ b/src/packages/flutter-app/test/home_travels_band_test.dart
@@ -46,7 +46,13 @@ String _iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
     '${d.month.toString().padLeft(2, '0')}-'
     '${d.day.toString().padLeft(2, '0')}';
 
-String _rel(int days) => _iso(DateTime.now().add(Duration(days: days)));
+// Calendar-day arithmetic, never Duration: adding 24h days lands a
+// calendar day short in the midnight hour when the span crosses a DST
+// fall-back (the trips_list_header "34 days" flake of 2026-08-23).
+String _rel(int days) {
+  final now = DateTime.now();
+  return _iso(DateTime(now.year, now.month, now.day + days));
+}
 
 Trip _trip(String id, String title, {String? start, String? end}) => Trip(
       id: id,

--- a/src/packages/flutter-app/test/travel_atlas_screen_test.dart
+++ b/src/packages/flutter-app/test/travel_atlas_screen_test.dart
@@ -59,7 +59,13 @@ String _iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
     '${d.month.toString().padLeft(2, '0')}-'
     '${d.day.toString().padLeft(2, '0')}';
 
-String _rel(int days) => _iso(DateTime.now().add(Duration(days: days)));
+// Calendar-day arithmetic, never Duration: adding 24h days lands a
+// calendar day short in the midnight hour when the span crosses a DST
+// fall-back (the trips_list_header "34 days" flake of 2026-08-23).
+String _rel(int days) {
+  final now = DateTime.now();
+  return _iso(DateTime(now.year, now.month, now.day + days));
+}
 
 /// A whole calendar year that is provably behind us whatever day the suite
 /// runs. Year membership is what the chips key on, so fixtures that care about

--- a/src/packages/flutter-app/test/trip_hero_card_test.dart
+++ b/src/packages/flutter-app/test/trip_hero_card_test.dart
@@ -21,7 +21,13 @@ String _iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
     '${d.month.toString().padLeft(2, '0')}-'
     '${d.day.toString().padLeft(2, '0')}';
 
-String _rel(int days) => _iso(DateTime.now().add(Duration(days: days)));
+// Calendar-day arithmetic, never Duration: adding 24h days lands a
+// calendar day short in the midnight hour when the span crosses a DST
+// fall-back (the trips_list_header "34 days" flake of 2026-08-23).
+String _rel(int days) {
+  final now = DateTime.now();
+  return _iso(DateTime(now.year, now.month, now.day + days));
+}
 
 Trip _trip({String? start, String? end, String? nextTransportDepart}) => Trip(
       id: 't1',

--- a/src/packages/flutter-app/test/trips_list_enrichment_test.dart
+++ b/src/packages/flutter-app/test/trips_list_enrichment_test.dart
@@ -48,7 +48,13 @@ String _iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
     '${d.month.toString().padLeft(2, '0')}-'
     '${d.day.toString().padLeft(2, '0')}';
 
-String _rel(int days) => _iso(DateTime.now().add(Duration(days: days)));
+// Calendar-day arithmetic, never Duration: adding 24h days lands a
+// calendar day short in the midnight hour when the span crosses a DST
+// fall-back (the trips_list_header "34 days" flake of 2026-08-23).
+String _rel(int days) {
+  final now = DateTime.now();
+  return _iso(DateTime(now.year, now.month, now.day + days));
+}
 
 Future<void> _pumpList(WidgetTester tester, List<Trip> trips,
     {_FixedTripsApiService? service}) {

--- a/src/packages/flutter-app/test/trips_list_footprint_test.dart
+++ b/src/packages/flutter-app/test/trips_list_footprint_test.dart
@@ -54,7 +54,13 @@ String _iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
     '${d.month.toString().padLeft(2, '0')}-'
     '${d.day.toString().padLeft(2, '0')}';
 
-String _rel(int days) => _iso(DateTime.now().add(Duration(days: days)));
+// Calendar-day arithmetic, never Duration: adding 24h days lands a
+// calendar day short in the midnight hour when the span crosses a DST
+// fall-back (the trips_list_header "34 days" flake of 2026-08-23).
+String _rel(int days) {
+  final now = DateTime.now();
+  return _iso(DateTime(now.year, now.month, now.day + days));
+}
 
 Trip _trip(String id, String title,
         {String? start,

--- a/src/packages/flutter-app/test/trips_list_header_test.dart
+++ b/src/packages/flutter-app/test/trips_list_header_test.dart
@@ -34,7 +34,13 @@ String _iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
     '${d.month.toString().padLeft(2, '0')}-'
     '${d.day.toString().padLeft(2, '0')}';
 
-String _rel(int days) => _iso(DateTime.now().add(Duration(days: days)));
+// Calendar-day arithmetic, never Duration: adding 24h days lands a
+// calendar day short in the midnight hour when the span crosses a DST
+// fall-back (the trips_list_header "34 days" flake of 2026-08-23).
+String _rel(int days) {
+  final now = DateTime.now();
+  return _iso(DateTime(now.year, now.month, now.day + days));
+}
 
 Trip _trip(String id, String title,
         {String? start, String? end, List<String>? cities, String? access}) =>

--- a/src/packages/flutter-app/test/trips_list_live_test.dart
+++ b/src/packages/flutter-app/test/trips_list_live_test.dart
@@ -59,7 +59,13 @@ String _iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
     '${d.month.toString().padLeft(2, '0')}-'
     '${d.day.toString().padLeft(2, '0')}';
 
-String _rel(int days) => _iso(DateTime.now().add(Duration(days: days)));
+// Calendar-day arithmetic, never Duration: adding 24h days lands a
+// calendar day short in the midnight hour when the span crosses a DST
+// fall-back (the trips_list_header "34 days" flake of 2026-08-23).
+String _rel(int days) {
+  final now = DateTime.now();
+  return _iso(DateTime(now.year, now.month, now.day + days));
+}
 
 Trip _trip(String id, String title, {String? start, String? end}) => Trip(
       id: id,

--- a/src/packages/flutter-app/test/trips_list_log_trip_entry_test.dart
+++ b/src/packages/flutter-app/test/trips_list_log_trip_entry_test.dart
@@ -39,7 +39,13 @@ String _iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
     '${d.month.toString().padLeft(2, '0')}-'
     '${d.day.toString().padLeft(2, '0')}';
 
-String _rel(int days) => _iso(DateTime.now().add(Duration(days: days)));
+// Calendar-day arithmetic, never Duration: adding 24h days lands a
+// calendar day short in the midnight hour when the span crosses a DST
+// fall-back (the trips_list_header "34 days" flake of 2026-08-23).
+String _rel(int days) {
+  final now = DateTime.now();
+  return _iso(DateTime(now.year, now.month, now.day + days));
+}
 
 Trip _trip(String id, {String? start, String? end}) => Trip(
       id: id,

--- a/src/packages/flutter-app/test/trips_list_past_section_test.dart
+++ b/src/packages/flutter-app/test/trips_list_past_section_test.dart
@@ -34,7 +34,13 @@ String _iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
     '${d.month.toString().padLeft(2, '0')}-'
     '${d.day.toString().padLeft(2, '0')}';
 
-String _rel(int days) => _iso(DateTime.now().add(Duration(days: days)));
+// Calendar-day arithmetic, never Duration: adding 24h days lands a
+// calendar day short in the midnight hour when the span crosses a DST
+// fall-back (the trips_list_header "34 days" flake of 2026-08-23).
+String _rel(int days) {
+  final now = DateTime.now();
+  return _iso(DateTime(now.year, now.month, now.day + days));
+}
 
 Trip _trip(String id, String title,
         {String? start, String? end, List<String>? cities}) =>

--- a/src/packages/flutter-app/test/trips_list_title_test.dart
+++ b/src/packages/flutter-app/test/trips_list_title_test.dart
@@ -32,7 +32,13 @@ String _iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
     '${d.month.toString().padLeft(2, '0')}-'
     '${d.day.toString().padLeft(2, '0')}';
 
-String _rel(int days) => _iso(DateTime.now().add(Duration(days: days)));
+// Calendar-day arithmetic, never Duration: adding 24h days lands a
+// calendar day short in the midnight hour when the span crosses a DST
+// fall-back (the trips_list_header "34 days" flake of 2026-08-23).
+String _rel(int days) {
+  final now = DateTime.now();
+  return _iso(DateTime(now.year, now.month, now.day + days));
+}
 
 Trip _trip(String id, String title, {List<String>? cities}) => Trip(
       id: id,

--- a/src/packages/flutter-app/test/trips_list_up_next_test.dart
+++ b/src/packages/flutter-app/test/trips_list_up_next_test.dart
@@ -49,7 +49,13 @@ String _iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
     '${d.month.toString().padLeft(2, '0')}-'
     '${d.day.toString().padLeft(2, '0')}';
 
-String _rel(int days) => _iso(DateTime.now().add(Duration(days: days)));
+// Calendar-day arithmetic, never Duration: adding 24h days lands a
+// calendar day short in the midnight hour when the span crosses a DST
+// fall-back (the trips_list_header "34 days" flake of 2026-08-23).
+String _rel(int days) {
+  final now = DateTime.now();
+  return _iso(DateTime(now.year, now.month, now.day + days));
+}
 
 Trip _trip(String id, String title,
         {String? start,


### PR DESCRIPTION
## What

`trips_list_header_test.dart`'s *"a plain row prints its span on the date line"* failed on 2026-08-23 and passed on 2026-08-24 **with the same tree** — flagged independently by two lanes as a phantom red.

Mechanism: the `_rel(n)` fixture helper built dates with `DateTime.now().add(Duration(days: n))`, which adds absolute 24-hour days. When the fixture window (`_rel(40)`→`_rel(73)`) crosses the Nov 1, 2026 DST fall-back **and the suite runs between midnight and 1am local** (overnight sessions are the norm here), the far endpoint lands one calendar day short — the 34-day span renders as 33 and the assertion fails.

Fix: component-based date construction — `DateTime(now.year, now.month, now.day + n)` — normalizes in calendar days and cannot shift across DST transitions. Applied to **all 11 copies** of the helper (`trips_list_*`, `trip_hero_card`, `home_travels_band`, `travel_atlas_screen`), not just the file that bit: same latent flake everywhere. Two other test files already used the safe form.

Test-only change; no lib code touched.

## Verification

- All 11 touched files: **98 tests, 0 failures**, exit 0 captured directly from the runner
- `flutter analyze --no-fatal-infos --fatal-warnings`: exit 0 (3 pre-existing infos in route_response.dart, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)