### PR TITLE
fix(trip-detail): add-place dialog updates in place, without the full-page spinner

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -1729,8 +1729,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       builder: (_) => AddItineraryItemDialog(trip: trip, initialDay: day),
     );
     if (added == true) {
-      await _load();
-      if (!mounted) return; // _load awaited: the screen may be gone
+      // Silent, like every other item mutation: adding one place must not
+      // swap the body for the full-screen spinner (the last loud reload on
+      // this screen — the menu flows moved in #565/#566).
+      await _refresh();
+      if (!mounted) return; // awaited: the screen may be gone
       // Open whatever it landed in, then point the map at it. The map write
       // is THIS path's alone: adding one place is a request to look at it.
       final legKey = _revealNewItems(beforeIds);

--- a/src/packages/flutter-app/test/trip_detail_item_delete_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_item_delete_test.dart
@@ -270,6 +270,43 @@ void main() {
   });
 
   testWidgets(
+      'adding a place via the dialog updates in place — no full-screen reload',
+      (WidgetTester tester) async {
+    _useTallViewport(tester);
+    final fake = await _pump(
+      tester,
+      _tripWith([
+        _item(0, 'Louvre', 'attraction', day: 1, city: 'Paris'),
+        _item(1, 'Orsay', 'attraction', day: 1, city: 'Paris'),
+      ]),
+    );
+
+    await tester.tap(find.text('Add place').first);
+    await tester.pumpAndSettle();
+    // The dialog's manual-entry path: no search round-trip needed.
+    await tester.tap(find.text("Can't find it? Add manually"));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+        find.widgetWithText(TextField, 'Place name'), 'Pompidou');
+
+    fake.getTripGate = Completer<void>();
+    await tester.tap(find.text('Add'));
+    await _pumpUntilReloadInFlight(tester, fake);
+    // Let the dialog's pop animation finish — the reload is still gated, so
+    // this is the frame a loud _load() would have spent on the spinner.
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump();
+
+    // Mid-reload: the dialog is gone and the list stays on screen.
+    expect(find.text('Orsay'), findsOneWidget);
+
+    fake.getTripGate!.complete();
+    await tester.pumpAndSettle();
+    expect(find.text('Pompidou'), findsOneWidget);
+    expect(find.text('Orsay'), findsOneWidget);
+  });
+
+  testWidgets(
       'saving the reorder-section sheet updates in place — no full-screen reload',
       (WidgetTester tester) async {
     _useTallViewport(tester);


### PR DESCRIPTION
## What

Completes the sweep #565/#566 started. The manual "+ Add place" dialog was the last flow on the trip detail page awaiting the loud `_load()` — a full-screen spinner for a one-item change. It now awaits the silent `_refresh()`.

The post-add reveal-and-map-focus sequence is safe under the swap: `_refresh()` queues behind an in-flight fetch and its future resolves only after a round that **started after** the write, so `_revealNewItems`/`_setMapFocus` always read post-add state.

Every item mutation on the trip detail page — delete, undo, move, edit, section reorder, add — is now an in-place update.

## Tests

Extended `test/trip_detail_item_delete_test.dart` with the add flow: opens the dialog, takes the manual-entry path ("Can't find it? Add manually"), names the place, saves, gates the post-add fetch mid-flight past the dialog's pop animation, and asserts the itinerary stays mounted. **Fails against the old code** — 0 list widgets on that frame, body swapped for the spinner — and passes with the fix.

- Trip-detail suite: **449 tests, 0 failures** (`flutter test test/trip_detail*.dart`, exit 0 captured directly from the runner)
- `flutter analyze --no-fatal-infos --fatal-warnings`: exit 0 (3 pre-existing infos in route_response.dart, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790331531&installation_model_id=433099&pr_number=571&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F571&signature=8ca9ac7234bfb47ca6cd96934b1cac9b972c232502232055a78ada418de7ba36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->