### PR TITLE
feat(web-boot): dart2wasm/skwasm dual build — −24% cold wire and multithreaded raster for Blink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,10 +170,14 @@ jobs:
       # this is the only web compile, so it runs with the PRODUCTION flags:
       # the old flagless build never exercised --base-href/APP_BASE_PATH,
       # which is the exact parity gap behind the #320 service-worker bug.
+      # --wasm mirrors the image build and keeps a dart2wasm-incompatible
+      # dependency from landing unnoticed; the dual compile makes this step
+      # a few minutes slower on PRs.
       - name: flutter build web (prod-parity compile check)
         if: github.event_name == 'pull_request'
         run: >
           flutter build web
+          --wasm
           --base-href /app/
           --dart-define=API_BASE_URL=/api/v1
           --dart-define=APP_BASE_PATH=/app/

--- a/dockerize/deployment/Dockerfile
+++ b/dockerize/deployment/Dockerfile
@@ -48,7 +48,14 @@ RUN mkdir -p web/icons
 RUN dart run build_runner build --delete-conflicting-outputs
 
 # --web-renderer was removed in Flutter 3.32+ (canvaskit is the default).
-RUN flutter build web --release \
+# --wasm emits BOTH builds — dart2wasm+skwasm plus the dart2js+canvaskit
+# fallback — and flutter_bootstrap.js picks per browser at runtime: WasmGC
+# Blink browsers load skwasm (multithreaded, because /app/ already serves
+# COOP/COEP), everyone else keeps the exact JS path they get today. The
+# dual compile roughly doubles this step. Requires flutter_secure_storage
+# >= 10 (pubspec.yaml records why); the four guarded service-worker seds
+# below were verified against a --wasm build's output.
+RUN flutter build web --release --wasm \
     --base-href /app/ \
     --dart-define=API_BASE_URL=/api/v1 \
     --dart-define=APP_BASE_PATH=/app/
@@ -160,6 +167,17 @@ RUN sed -i 's/return response || fetch(event\.request)/return response || fetch(
 # entrypoint are both retained in -slim. Minor-version pinned: 1.31.x is
 # what production already runs; bumps are explicit, reviewable edits.
 FROM nginx:1.31-alpine-slim
+
+# nginx's stock mime.types maps `js` but not `mjs` (still true in 1.31), so
+# main.dart.mjs would ship as application/octet-stream. The wasm entrypoint
+# loads it via dynamic import(), which REQUIRES a JavaScript MIME type — and
+# X-Content-Type-Options: nosniff (security-headers.conf) makes the mismatch
+# a hard block, not a warning: every wasm-eligible browser white-screens, and
+# the bootstrap has no runtime fallback to the JS build. Guarded like the
+# service-worker patches above: fail the image build loudly if a base-image
+# bump ever reshapes the line this edits.
+RUN sed -E -i 's|(application/javascript[[:space:]]+js);|\1 mjs;|' /etc/nginx/mime.types \
+    && grep -qE 'application/javascript[[:space:]]+js mjs;' /etc/nginx/mime.types
 
 # default.conf is the local :80 server shell; the production stack
 # volume-mounts dockerize/production/nginx/prod.conf over it. The shared

--- a/dockerize/deployment/nginx/snippets/app-locations.conf
+++ b/dockerize/deployment/nginx/snippets/app-locations.conf
@@ -173,17 +173,21 @@ location /app/ {
 # What the CLIENT actually sees is split, because Cloudflare's Browser Cache
 # TTL (4 h default) rewrites `no-cache` for any extension it caches:
 # index.html/version.json/manifest.json are `.html`/`.json`, which Cloudflare
-# does not cache, so they arrive `no-cache` intact; the four .js members arrive
-# `max-age=14400`. The edge revalidates against us either way, so a new deploy
-# is always available — but a returning browser can hold .js for up to 4 h.
-# Three of the four are immune anyway: main.dart.js and flutter_bootstrap.js
-# sit in the service worker's CORE list, which install() fetches with
-# {'cache': 'reload'}, and flutter_service_worker.js is exempt because browsers
+# does not cache, so they arrive `no-cache` intact; the .js members arrive
+# `max-age=14400`, and main.dart.wasm/.mjs — the dart2wasm build's
+# entrypoints, equally uncontent-hashed and rewritten in place by every
+# deploy — get whatever Cloudflare's cached-extension list says on the day.
+# The edge revalidates against us either way, so a new deploy is always
+# available — but a returning browser can hold a member for up to 4 h.
+# Nearly all are immune anyway: main.dart.js, main.dart.wasm and
+# main.dart.mjs sit in the service worker's CORE list (alongside index.html
+# and flutter_bootstrap.js), which install() fetches with {'cache':
+# 'reload'}, and flutter_service_worker.js is exempt because browsers
 # bypass the HTTP cache when checking a worker script for updates. Only
 # flutter.js is genuinely exposed, and it is SDK loader boilerplate that
 # changes on Flutter upgrades. Do not drop a file from CORE while relying on
 # this block alone.
-location ~ ^/app/(?:index\.html|flutter_service_worker\.js|flutter_bootstrap\.js|main\.dart\.js|flutter\.js|version\.json|manifest\.json)$ {
+location ~ ^/app/(?:index\.html|flutter_service_worker\.js|flutter_bootstrap\.js|main\.dart\.js|main\.dart\.wasm|main\.dart\.mjs|flutter\.js|version\.json|manifest\.json)$ {
     add_header Cache-Control "no-cache";
     add_header Cross-Origin-Embedder-Policy require-corp;
     add_header Cross-Origin-Opener-Policy same-origin;


### PR DESCRIPTION
## Summary
- Adds `--wasm` to the image build and CI's PR prod-parity build: the deploy now ships **both** builds, and `flutter_bootstrap.js` selects per browser at runtime — WasmGC Blink browsers get `main.dart.wasm` + multithreaded skwasm (COOP/COEP is already live on `/app/`), Firefox/Safari/older browsers keep today's `main.dart.js` + gstatic canvaskit path byte-for-byte.
- Two load-bearing serving fixes found by probing (write-up: epic artifact `trip-detail-first-paint/wasm-build`):
  - **`.mjs` MIME**: nginx 1.31's stock `mime.types` maps `js` but not `mjs`; `main.dart.mjs` loads via dynamic `import()`, which requires a JavaScript MIME, and `nosniff` makes the mismatch fatal — white screen on every wasm-eligible browser, no runtime fallback. Fixed with a guarded sed in the nginx stage, same style as the service-worker patches.
  - **Cache headers**: `main.dart.wasm`/`main.dart.mjs` join the no-cache app-shell regex — both rewritten in place per deploy, not content-hashed: the exact 2026-08-14 stale-edge failure class. Both sit in the SW CORE, so the `{cache:"reload"}` install fetch defends installed clients and the header defends first visits.
- Measured effect (gzip wire, Chrome-class): ~4.40 → ~3.35 MB (**−24%**) — app +0.33 MB, engine −1.37 MB — plus the engine moving same-origin into the SW precache and streaming wasm compilation replacing the 5.5 MB JS parse.
- Depends on #569 (already merged): `flutter_secure_storage` 9.x was the sole dart2wasm blocker; the new CI `--wasm` build keeps any future one from landing unnoticed.

## Testing
- Full `--wasm` build with the prod flags succeeds on this tree (`✓ Built build/web`).
- The real `nginx:1.31.3-alpine-slim` was booted with the edited config tree and the exact sed applied: `main.dart.mjs` → `application/javascript` + `no-cache`; `main.dart.wasm` → `application/wasm` + `no-cache`; existing shell members unchanged; `nginx -t` clean; the sed's grep guard passes.
- All four existing guarded service-worker seds and the KaTeX-strip grep verified to match a `--wasm` build's output; SW CORE confirmed to contain `main.dart.js`, `main.dart.wasm`, `main.dart.mjs`.
- No Dart source changes — the Flutter suite is unaffected by this diff (CI runs it regardless).

## Post-merge watch list
- First image build: confirm `flutter precache --web` pulled the wasm artifacts (the existing `flutter_web_sdk` guard should scream if not).
- First deploy: `verify-edge-parity.sh` self-adapts via the SW RESOURCES map — watch it pass with the new files.
- Renderer smoke in a Blink browser (the taste calls a build can't make): trip-detail satellite map tiles, the Cormorant Garamond splash handoff, chat markdown, and the password-manager autofill shim under multithreading. DevTools console will say `skwasm` was selected.
- Known accepted cost: every client's SW install backgrounds ~1.5–1.9 MB gz for the variant it will never run, once per deploy. A variant-aware CORE patch is possible later if it proves to matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790331541&installation_model_id=433099&pr_number=572&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F572&signature=2f9eaa7669e63a43bbcf1ce3d712c410fffa1d14d0937d60c83c7aa74f06e4a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->