### PR TITLE
fix(legs): a boundary segment rides its destination city's arrival, never a synthetic end

### DIFF
--- a/src/packages/api/plan_leg_dates.go
+++ b/src/packages/api/plan_leg_dates.go
@@ -13,8 +13,20 @@ package main
 // keeps its within-leg offset, and no item is ever dragged onto a departure
 // day (the old END-anchored renumber moved places the traveler deliberately
 // kept off the travel day; ticket 2 removed it). One transaction renumbers
-// the items, moves the leg's matched confirmed stays and boundary transport,
-// and extends the trip's end date when the leg now runs past it.
+// the items, moves the leg's matched confirmed stays and the transport the
+// leg OWNS, and extends the trip's end date when the leg now runs past it.
+//
+// Transport ownership follows the same rule (ticket 5): a boundary segment's
+// day belongs to the ARRIVAL it serves. A segment arriving at this city rides
+// this leg's start; one departing to another city of the trip is that city's
+// arrival transport and moves only with that city's own call — never here,
+// which is how a chained repair once moved one flight twice. A departing
+// segment with no arrival-side owner (the journey home) rides this leg's end
+// only when this call moved a REAL stored end — the confirmed stay's
+// check-out or the final leg's trip-end extension — because on any other move
+// endDelta is the length-preserving synthetic, an end the call did not
+// change, and moving a confirmed booking by it desyncs the flight from the
+// page.
 //
 // An explicit end_date is honoured only where the departure actually lives on
 // this leg's own rows: a confirmed stay's check-out, or — for the trip's
@@ -58,8 +70,8 @@ import (
 var setLegDatesTool = anthropic.ToolParam{
 	Name: "set_leg_dates",
 	Description: anthropic.String("Change when ONE city's leg of the traveler's saved trip happens — 'arrive in Rome a day later' — without moving the rest of the trip. " +
-		"start_date moves the city's ARRIVAL: its itinerary days shift together, its stay's dates move, and the transport into and out of the city follows. " +
-		"A city's departure day is the NEXT city's arrival, so to change when the traveler LEAVES a city, move the next city's start_date (or use shift_days_from to push it and everything after it together). " +
+		"start_date moves the city's ARRIVAL: its itinerary days shift together, its stay's dates move, and the transport INTO the city follows. " +
+		"A city's departure day is the NEXT city's arrival, so to change when the traveler LEAVES a city, move the next city's start_date (or use shift_days_from to push it and everything after it together) — transport onward to another city of the trip rides THAT city's arrival and moves with it, never with this call. " +
 		"end_date is honoured only where the departure lives on this city's own plan: its confirmed stay's check-out, or — for the trip's final city — the trip's end date, which extends when the leg runs past it. Anywhere else an explicit end_date is refused with the call to make instead. Omit end_date to keep the leg's saved length. " +
 		"When the WHOLE trip moves, use set_trip_dates instead. " +
 		"The result reports the dates the trip page now renders — relay any range that doesn't match what the traveler asked for. " +
@@ -591,13 +603,17 @@ func runSetLegDatesTool(s *planSession, input json.RawMessage) (string, bool) {
 	if movedLegNow != nil {
 		nextSpannedNow = nextSpannedRenderedLeg(legsNow, movedLegNow)
 	}
+	// The one stay that anchors this leg's rendered end (and start) — the
+	// predicate the first-leg carve-out, the end_date gate, transport
+	// ownership and the no-op report all share.
+	runStay := matchedConfirmedStay(run, stays)
 
 	// The first leg's arrival IS the trip's start date (its span is anchored
 	// there), so a different start is really a trip-start change — steer to
 	// set_trip_dates rather than silently re-numbering items into a shape the
 	// screen can't show. Carve-out: a confirmed stay anchors the leg's start
 	// instead, and its check-in stays movable like any other leg's.
-	if matched[0] == firstDatedRunIdx(runs) && matchedConfirmedStay(run, stays) == nil && !start.Time.Equal(tripStart) {
+	if matched[0] == firstDatedRunIdx(runs) && runStay == nil && !start.Time.Equal(tripStart) {
 		return fmt.Sprintf("%s is the trip's first city, so its arrival IS the trip's start date (%s). To move when the trip begins, use set_trip_dates; a city's departure day is the NEXT city's arrival, so to change when the traveler leaves %s, move the next city's start_date instead.",
 			run.hub, tripStart.Format(dateLayout), run.hub), true
 	}
@@ -611,8 +627,14 @@ func runSetLegDatesTool(s *planSession, input json.RawMessage) (string, bool) {
 	// Sep 24 to 27" when Sep 27 is already the on-screen end is a start move);
 	// anything else refuses with the call that actually moves the boundary —
 	// applying the start half anyway would be the tool fighting the traveler.
+	// endOwned: this call moves a REAL stored end — the leg's confirmed
+	// stay's check-out (the stays loop moves it by endDelta on every accepted
+	// move, rigid or endpoint-anchored), or the final leg's trip-end
+	// extension below. Only such an end may carry departing transport; on
+	// every other move endDelta is the length-preserving synthetic.
 	endBasis := oldLegEnd
-	if newEnd != nil && matchedConfirmedStay(run, stays) == nil {
+	endOwned := runStay != nil
+	if newEnd != nil && runStay == nil {
 		switch {
 		case movedLegNow != nil && movedLegNow.End != nil && newEnd.Equal(*movedLegNow.End):
 			newEnd = nil
@@ -637,6 +659,7 @@ func runSetLegDatesTool(s *planSession, input json.RawMessage) (string, bool) {
 			// it — the raw last item day runs short of it by however many
 			// place-free tail nights the leg holds.
 			endBasis = trip.EndDate.Time
+			endOwned = true
 		}
 	}
 
@@ -740,10 +763,22 @@ func runSetLegDatesTool(s *planSession, input json.RawMessage) (string, bool) {
 		staysMoved++
 	}
 
-	// Boundary transport (confirmed only): a segment arriving at the hub
-	// rides the leg start, one departing it rides the leg end, one inside
-	// the leg rides the start.
+	// Boundary transport (confirmed only): a segment's calendar day belongs
+	// to the ARRIVAL it serves — the boundary rule, applied to transport. One
+	// arriving at the hub rides this leg's start; one inside the leg rides
+	// the start. One DEPARTING the hub toward another dated city of the trip
+	// is THAT city's arrival transport and moves only with that city's own
+	// call — moving it here too is how a chained repair (stay-checkout end,
+	// then next city's start) used to move one flight twice, and within a
+	// call it is the same ownership the movedStayIDs guard gives stays. What
+	// remains (the journey home, a destination outside the trip) rides this
+	// leg's end only when endOwned — a real stored end this call moved. On a
+	// start-only items-leg move endDelta is the length-preserving synthetic
+	// for an end that post-boundary-rule is the next city's arrival, and
+	// moving a confirmed booking by it silently desyncs the flight from the
+	// page (specs/leg-departure-dates ticket 5).
 	arrMoved, depMoved := 0, 0
+	var depLeftForArrival []string
 	for _, seg := range segs {
 		if seg.Auto {
 			continue
@@ -755,6 +790,20 @@ func runSetLegDatesTool(s *planSession, input json.RawMessage) (string, bool) {
 		case destMatch:
 			delta = ch.startDelta
 		case origMatch:
+			if owner := segDestLegHub(runs, matched[0], strPtrVal(seg.Destination)); owner != "" {
+				// Arrival-owned. Named in the result only when this call DID
+				// move a real end (the model may expect the flight to follow
+				// the check-out it just moved); a bare arrival move skipping
+				// it is not an event — the segment already sits where the
+				// page says the boundary is.
+				if endOwned && ch.endDelta != 0 {
+					depLeftForArrival = append(depLeftForArrival, owner)
+				}
+				continue
+			}
+			if !endOwned {
+				continue
+			}
 			delta, departure = ch.endDelta, true
 		default:
 			continue
@@ -824,8 +873,8 @@ func runSetLegDatesTool(s *planSession, input json.RawMessage) (string, bool) {
 		itemEnd := tripStart.AddDate(0, 0, run.maxDay-1)
 		var b strings.Builder
 		fmt.Fprintf(&b, "No saved rows changed. Actual saved state for %s: itinerary items sit on %s (trip days %d-%d)", run.hub, legRangeText(itemStart, itemEnd), run.minDay, run.maxDay)
-		if a := matchedConfirmedStay(run, stays); a != nil {
-			fmt.Fprintf(&b, "; its confirmed stay %q runs %s", a.Name, legRangeText(a.CheckIn.Time, a.CheckOut.Time))
+		if runStay != nil {
+			fmt.Fprintf(&b, "; its confirmed stay %q runs %s", runStay.Name, legRangeText(runStay.CheckIn.Time, runStay.CheckOut.Time))
 		}
 		if prevSpanned := prevSpannedRenderedLeg(legsNow, movedLegNow); prevSpanned != nil {
 			fmt.Fprintf(&b, "; on the page the previous leg (%s) runs through %s", prevSpanned.Label, prevSpanned.End.Format(dateLayout))
@@ -920,6 +969,9 @@ func runSetLegDatesTool(s *planSession, input json.RawMessage) (string, bool) {
 	if prevExtended {
 		fmt.Fprintf(&b, " %s now ends %s (was %s) — its stay's check-out moved to match this leg's arrival.", prevRun.hub, ch.newStart.Format(dateLayout), prevWasEnd.Format(dateLayout))
 	}
+	if len(depLeftForArrival) > 0 {
+		fmt.Fprintf(&b, " NOTE: the confirmed transport out of %s (to %s) was deliberately left in place — a boundary segment rides its destination city's arrival, so it moves when that city's dates do.", run.hub, strings.Join(depLeftForArrival, ", "))
+	}
 
 	// Overlaps ARE representable on the page (an explicit stay running past a
 	// neighbour's arrival), so they are the one neighbour condition still
@@ -977,6 +1029,31 @@ func postMoveState(s *planSession, tripID uuid.UUID) (postMoveTripState, bool) {
 		return postMoveTripState{}, false
 	}
 	return postMoveTripState{trip: trip, items: items, stays: stays}, true
+}
+
+// segDestLegHub resolves whether a departing segment's destination is another
+// dated named city leg of this trip — the leg whose ARRIVAL the segment
+// serves, and therefore its owner: that city's own set_leg_dates destMatches
+// it and moves it by that leg's start delta. Returns the owning run's hub
+// ("" when the destination matches no other dated named run — a journey-home
+// or out-of-trip destination, which the end side may carry). Any other run
+// qualifies, not just the next one: a revisit's return segment belongs to the
+// revisit leg, and the matching is the same fuzzyMatch the loop applies to
+// this hub's own endpoints.
+func segDestLegHub(runs []legRun, selfIdx int, dest string) string {
+	destLower := strings.ToLower(strings.TrimSpace(dest))
+	if destLower == "" {
+		return ""
+	}
+	for i, r := range runs {
+		if i == selfIdx || r.minDay < 1 || r.hub == "" {
+			continue
+		}
+		if fuzzyMatch(destLower, strings.ToLower(r.hub)) {
+			return r.hub
+		}
+	}
+	return ""
 }
 
 // prevDatedRunIdx finds the nearest movable neighbor before a run — the leg

--- a/src/packages/api/plan_leg_dates_test.go
+++ b/src/packages/api/plan_leg_dates_test.go
@@ -14,9 +14,12 @@ package main
 // assert the headline dogfood scenario (Panama City -> LA -> EWR, "change LA
 // to Sep 24-27"), the placeholder start-carrier shape, honest zero-change
 // results (no commit, no trip_updated), the end_date gate's three verdicts,
-// the shrink clamp, the auto-draft skip, overlap narration from rendered
-// spans, validation atomicity, collaborator authz, and lineage resolution on
-// a later turn.
+// transport ownership (ticket 5: a boundary segment rides its destination
+// city's arrival; departing transport moves only with a REAL end — stay
+// check-out or final-leg extension — and a chained repair moves a shared
+// segment exactly once), the shrink clamp, the auto-draft skip, overlap
+// narration from rendered spans, validation atomicity, collaborator authz,
+// and lineage resolution on a later turn.
 
 import (
 	"context"
@@ -1262,6 +1265,266 @@ func TestPlanSetLegDatesLastLegShrinkSteersToTripDates(t *testing.T) {
 	}
 	if _, end := tripDates(t, trip.ID); end != "2026-09-27" {
 		t.Fatalf("trip end = %s, want untouched 2026-09-27", end)
+	}
+}
+
+// seedTransportOwnershipTrip: an items-dated Copenhagen → Berlin → Gothenburg
+// trip (Sep 7–17, no stays) with three confirmed segments — one arriving at
+// the interior leg (Copenhagen→Berlin Sep 10, Berlin's arrival day), one
+// boundary (Berlin→Gothenburg Sep 14, the day Gothenburg begins), one journey
+// home (Gothenburg→Newark Sep 17, the trip's end). Without stays every leg's
+// rendered end is a neighbour's arrival or the trip's end — the shapes
+// transport ownership (ticket 5) is decided by.
+func seedTransportOwnershipTrip(t *testing.T, trip store.Trip, owner uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+	q := store.New(dbPool)
+	if _, err := q.UpdateTrip(ctx, store.UpdateTripParams{
+		ID: trip.ID, UserID: owner,
+		StartDate: validDate("2026-09-07"), EndDate: validDate("2026-09-17"),
+	}); err != nil {
+		t.Fatalf("seed trip dates: %v", err)
+	}
+	for i, seed := range []struct {
+		name, city string
+		day        int
+	}{
+		{"Nyhavn", "Copenhagen", 1},
+		{"Tivoli Gardens", "Copenhagen", 2},
+		{"Museum Island", "Berlin", 4},
+		{"East Side Gallery", "Berlin", 6},
+		{"Haga District", "Gothenburg", 8},
+		{"Liseberg", "Gothenburg", 10},
+	} {
+		d := int32(seed.day)
+		city := seed.city
+		if _, err := q.CreateItineraryItem(ctx, store.CreateItineraryItemParams{
+			TripID: trip.ID, Position: int32(i), Name: seed.name,
+			City: &city, Day: &d, Latitude: 52.51, Longitude: 13.39,
+		}); err != nil {
+			t.Fatalf("seed item %s: %v", seed.name, err)
+		}
+	}
+	for _, seg := range []struct {
+		origin, dest, depart string
+	}{
+		{"Copenhagen", "Berlin", "2026-09-10"},
+		{"Berlin", "Gothenburg", "2026-09-14"},
+		{"Gothenburg", "Newark", "2026-09-17"},
+	} {
+		o, d := seg.origin, seg.dest
+		if _, err := q.CreateSegment(ctx, store.CreateSegmentParams{
+			TripID: trip.ID, Mode: "flight", Origin: &o, Destination: &d,
+			DepartDate: validDate(seg.depart),
+		}); err != nil {
+			t.Fatalf("seed segment %s->%s: %v", seg.origin, seg.dest, err)
+		}
+	}
+}
+
+// Symptom A of specs/leg-departure-dates ticket 5, pinned: a start-only move
+// of an items-leg moves NO departing confirmed segment. Berlin's rendered
+// departure is Gothenburg's arrival — a date this call does not touch — so
+// the Berlin→Gothenburg flight holding that day must not ride the synthetic
+// length-preserving endDelta (it used to move +2 here, silently desyncing a
+// confirmed booking from the page the traveler is looking at). The arriving
+// flight still rides the start — the arrival is the date this call moved.
+func TestPlanSetLegDatesStartOnlyLeavesDepartingTransport(t *testing.T) {
+	resetDB(t)
+	user, _ := createTestUser(t, "transown@example.com")
+	trip := createTestTrip(t, user.ID, 0)
+	seedTransportOwnershipTrip(t, trip, user.ID)
+
+	s, rec := testPlanSession(true, user.ID)
+	s.boundTripID = &trip.ID
+	msg, isErr := runSetLegDatesTool(s, []byte(`{"city":"Berlin","start_date":"2026-09-12"}`))
+	if isErr {
+		t.Fatalf("start-only move errored: %s", msg)
+	}
+	for _, want := range []string{
+		"Berlin is now 2026-09-12 to 2026-09-14 on the trip page",
+		"1 arriving and 0 departing transport leg(s)",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("result missing %q: %s", want, msg)
+		}
+	}
+	// A bare arrival move skipping the boundary flight is not an event: the
+	// segment already sits where the page says the boundary is.
+	if strings.Contains(msg, "left in place") {
+		t.Fatalf("bare arrival move narrated a transport skip: %s", msg)
+	}
+	if !strings.Contains(rec.Body.String(), "trip_updated") {
+		t.Fatal("start move did not emit trip_updated")
+	}
+	assertDatesFromRenderedLegs(t, msg, trip.ID, user.ID)
+	if got := legDays(t, trip.ID, "Berlin"); !daysEqual(got, 6, 8) {
+		t.Fatalf("Berlin days = %v, want [6 8]", got)
+	}
+	if dep, _ := scanDates(t, `SELECT depart_date, arrive_date FROM trip_segments WHERE trip_id = $1 AND origin = $2`, trip.ID, "Copenhagen"); dep != "2026-09-12" {
+		t.Fatalf("arriving flight departs %s, want 2026-09-12 (rides the leg start)", dep)
+	}
+	if dep, _ := scanDates(t, `SELECT depart_date, arrive_date FROM trip_segments WHERE trip_id = $1 AND origin = $2`, trip.ID, "Berlin"); dep != "2026-09-14" {
+		t.Fatalf("boundary flight departs %s, want 2026-09-14 UNMOVED — it rides Gothenburg's arrival", dep)
+	}
+	if dep, _ := scanDates(t, `SELECT depart_date, arrive_date FROM trip_segments WHERE trip_id = $1 AND origin = $2`, trip.ID, "Gothenburg"); dep != "2026-09-17" {
+		t.Fatalf("journey-home flight departs %s, want 2026-09-17 untouched", dep)
+	}
+}
+
+// The final leg is the open question the ticket left: its journey-home
+// segment matches origMatch legitimately, and its end delta is REAL there —
+// measured off the trip's end date (the endBasis path), which the same call
+// extends. The narrowing must not starve it. This is a does-not-regress
+// guard, not a bug pin: it passes before and after ticket 5, and goes red if
+// the ownership gate over-narrows (origMatch gated off entirely). The
+// boundary flight INTO the final city holds still on an end-only ask — its
+// day is the final city's arrival, which this call does not move.
+func TestPlanSetLegDatesFinalLegExtensionMovesJourneyHome(t *testing.T) {
+	resetDB(t)
+	user, _ := createTestUser(t, "journeyhome@example.com")
+	trip := createTestTrip(t, user.ID, 0)
+	seedTransportOwnershipTrip(t, trip, user.ID)
+
+	s, rec := testPlanSession(true, user.ID)
+	s.boundTripID = &trip.ID
+	msg, isErr := runSetLegDatesTool(s, []byte(`{"city":"Gothenburg","start_date":"2026-09-14","end_date":"2026-09-19"}`))
+	if isErr {
+		t.Fatalf("final-leg extension errored: %s", msg)
+	}
+	for _, want := range []string{
+		"Gothenburg is now 2026-09-14 to 2026-09-19 on the trip page",
+		"Trip end extended to 2026-09-19",
+		"0 arriving and 1 departing transport leg(s)",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("result missing %q: %s", want, msg)
+		}
+	}
+	if !strings.Contains(rec.Body.String(), "trip_updated") {
+		t.Fatal("extension did not emit trip_updated")
+	}
+	assertDatesFromRenderedLegs(t, msg, trip.ID, user.ID)
+	if dep, _ := scanDates(t, `SELECT depart_date, arrive_date FROM trip_segments WHERE trip_id = $1 AND origin = $2`, trip.ID, "Gothenburg"); dep != "2026-09-19" {
+		t.Fatalf("journey-home flight departs %s, want 2026-09-19 (rides the real trip-end extension)", dep)
+	}
+	if dep, _ := scanDates(t, `SELECT depart_date, arrive_date FROM trip_segments WHERE trip_id = $1 AND origin = $2`, trip.ID, "Berlin"); dep != "2026-09-14" {
+		t.Fatalf("boundary flight departs %s, want 2026-09-14 untouched (the final city's arrival did not move)", dep)
+	}
+	if _, end := tripDates(t, trip.ID); end != "2026-09-19" {
+		t.Fatalf("trip end = %s, want extended to 2026-09-19", end)
+	}
+}
+
+// Symptom B, the cross-call double-move, pinned as ownership: a Florence→Rome
+// flight is ROME's arrival transport, so a chained repair — extend Florence's
+// stay check-out (a real end change), then move Rome's start to meet it —
+// moves the flight EXACTLY once, with Rome's call. Before ticket 5 the first
+// call moved it too (origMatch × a real endDelta), landing the flight a day
+// past the boundary the chain agreed on; the movedStayIDs guard could never
+// see across calls — only ownership can.
+func TestPlanSetLegDatesChainMovesBoundarySegmentOnce(t *testing.T) {
+	resetDB(t)
+	user, _ := createTestUser(t, "chainonce@example.com")
+	trip := createTestTrip(t, user.ID, 0)
+	ctx := context.Background()
+	q := store.New(dbPool)
+	if _, err := q.UpdateTrip(ctx, store.UpdateTripParams{
+		ID: trip.ID, UserID: user.ID,
+		StartDate: validDate("2026-09-05"), EndDate: validDate("2026-09-16"),
+	}); err != nil {
+		t.Fatalf("seed trip dates: %v", err)
+	}
+	for i, seed := range []struct {
+		name, city string
+		day        int
+	}{
+		{"Duomo", "Florence", 1},
+		{"Uffizi", "Florence", 3},
+		{"Colosseum", "Rome", 6},
+		{"Trastevere", "Rome", 9},
+	} {
+		d := int32(seed.day)
+		city := seed.city
+		if _, err := q.CreateItineraryItem(ctx, store.CreateItineraryItemParams{
+			TripID: trip.ID, Position: int32(i), Name: seed.name,
+			City: &city, Day: &d, Latitude: 43.77, Longitude: 11.25,
+		}); err != nil {
+			t.Fatalf("seed item %s: %v", seed.name, err)
+		}
+	}
+	addr := "Piazza del Duomo, Florence, Italy"
+	if _, err := q.CreateAccommodation(ctx, store.CreateAccommodationParams{
+		TripID: trip.ID, Name: "Hotel Duomo", Address: &addr,
+		CheckIn: validDate("2026-09-05"), CheckOut: validDate("2026-09-10"),
+	}); err != nil {
+		t.Fatalf("seed Florence stay: %v", err)
+	}
+	fl, rm := "Florence", "Rome"
+	if _, err := q.CreateSegment(ctx, store.CreateSegmentParams{
+		TripID: trip.ID, Mode: "train", Origin: &fl, Destination: &rm,
+		DepartDate: validDate("2026-09-10"),
+	}); err != nil {
+		t.Fatalf("seed boundary segment: %v", err)
+	}
+
+	// Call 1: extend Florence's stay — a REAL end change (check-out moves to
+	// Sep 12), but the Florence→Rome train belongs to Rome's arrival and is
+	// deliberately left, and the result says so alongside the overlap it
+	// creates on the page.
+	s1, _ := testPlanSession(true, user.ID)
+	s1.boundTripID = &trip.ID
+	msg, isErr := runSetLegDatesTool(s1, []byte(`{"city":"Florence","start_date":"2026-09-05","end_date":"2026-09-12"}`))
+	if isErr {
+		t.Fatalf("stay-end extension errored: %s", msg)
+	}
+	for _, want := range []string{
+		"Florence is now 2026-09-05 to 2026-09-12 on the trip page",
+		"NOTE: the confirmed transport out of Florence (to Rome) was deliberately left in place",
+		"moves when that city's dates do",
+		"past Rome's arrival (2026-09-10)",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("call 1 result missing %q: %s", want, msg)
+		}
+	}
+	assertDatesFromRenderedLegs(t, msg, trip.ID, user.ID)
+	if dep, _ := scanDates(t, `SELECT depart_date, arrive_date FROM trip_segments WHERE trip_id = $1 AND origin = $2`, trip.ID, "Florence"); dep != "2026-09-10" {
+		t.Fatalf("after call 1 the boundary train departs %s, want 2026-09-10 (Rome's arrival owns it)", dep)
+	}
+	if _, out := scanDates(t, `SELECT check_in, check_out FROM accommodations WHERE trip_id = $1 AND name = $2`, trip.ID, "Hotel Duomo"); out != "2026-09-12" {
+		t.Fatalf("Florence check-out = %s, want 2026-09-12 (the real end change)", out)
+	}
+
+	// Call 2: move Rome to meet the check-out. The train moves NOW, by Rome's
+	// start delta — Sep 10 → Sep 12, exactly once. Under the old rule this
+	// landed on Sep 14: +2 with Florence's end, +2 again with Rome's start.
+	s2, _ := testPlanSession(true, user.ID)
+	s2.boundTripID = &trip.ID
+	msg, isErr = runSetLegDatesTool(s2, []byte(`{"city":"Rome","start_date":"2026-09-12"}`))
+	if isErr {
+		t.Fatalf("Rome start move errored: %s", msg)
+	}
+	for _, want := range []string{
+		"Rome is now 2026-09-12 to 2026-09-16 on the trip page",
+		"1 arriving and 0 departing transport leg(s)",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("call 2 result missing %q: %s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "overlapping") {
+		t.Fatalf("the chain closed the overlap; none may be narrated: %s", msg)
+	}
+	assertDatesFromRenderedLegs(t, msg, trip.ID, user.ID)
+	if dep, _ := scanDates(t, `SELECT depart_date, arrive_date FROM trip_segments WHERE trip_id = $1 AND origin = $2`, trip.ID, "Florence"); dep != "2026-09-12" {
+		t.Fatalf("boundary train departs %s, want 2026-09-12 — moved exactly once, with Rome", dep)
+	}
+	if got := legDays(t, trip.ID, "Rome"); !daysEqual(got, 8, 11) {
+		t.Fatalf("Rome days = %v, want [8 11]", got)
+	}
+	if _, out := scanDates(t, `SELECT check_in, check_out FROM accommodations WHERE trip_id = $1 AND name = $2`, trip.ID, "Hotel Duomo"); out != "2026-09-12" {
+		t.Fatalf("Florence check-out = %s, want 2026-09-12 still", out)
 	}
 }
 


### PR DESCRIPTION
**specs/leg-departure-dates, ticket 5.** Root-caused from ticket 2's found-not-fixed list: `set_leg_dates`' segment loop still moved confirmed **departing** transport by `ch.endDelta`, which a start-only move synthesizes from length preservation — an end delta for an end that, post-boundary-rule, is the next city's arrival and not a date the leg owns.

**Symptom A (common):** a start-only move of an items-leg shifted its confirmed departing flight while the page's departure day — the next city's arrival — stayed put. A confirmed booking silently desynced from the screen, and the model then reasoned from the wrong flight date.
**Symptom B (rare):** a chained repair (extend leg A's stay check-out, then move leg B's start) moved the shared A→B segment twice — the boundary moved one day, the flight moved two.

## The settled rule — the ticket's leaning, amended

Ownership, which is the boundary rule applied to transport: **a segment's calendar day belongs to the ARRIVAL it serves.**

- A segment departing toward **another dated city of the trip** is that city's arrival transport and moves **only** with that city's own call (`destMatch → startDelta`) — never with this one, whatever this call did to this leg's end.
- What remains for the end side (the journey home, destinations outside the trip) moves only when the call moved a **real stored end** — the leg's confirmed stay's check-out, or the final leg's trip-end extension (`endOwned`, on #562's `endBasis` path). Never the length-preserving synthetic.

The amendment matters: the ticket's leaning (real-end gating alone) kills symptom A but **not** symptom B — a stay-checkout end change *is* a real end change, so the shared segment would still have moved with A's call and again with B's. Arrival-side precedence is what makes the A/B chain move it exactly once, and it's the cross-call form of the ownership the `movedStayIDs` guard already gives stays within a call.

**The open question, answered yes:** the final leg's journey-home segment still moves — its destination matches no leg (no arrival-side owner), and its end delta is real (measured off the trip end the same call extends). Pinned.

## Narration

The moved-counts sentence only ever counted actual moves, so it stays honest by construction ("1 arriving and 0 departing transport leg(s)"). A new NOTE fires only when a **real-end** call deliberately left an arrival-owned segment — *"the confirmed transport out of Florence (to Rome) was deliberately left in place — a boundary segment rides its destination city's arrival, so it moves when that city's dates do."* — so the model doesn't assume the flight followed the check-out it just moved. A bare arrival move narrates nothing: the segment already sits where the page says the boundary is. The `assertDatesFromRenderedLegs` sweep runs on all three new pins. The tool description stops promising "transport into and out of the city follows" (registry entry **order** untouched).

## Pins, each verified fail-against-old

| Pin | Against old (`git stash` of the lib file, new tests kept) |
|---|---|
| `TestPlanSetLegDatesStartOnlyLeavesDepartingTransport` | **FAIL, exit 1** — old result: `1 arriving and 1 departing transport leg(s)`; the Berlin→Gothenburg flight rode the synthetic +2 |
| `TestPlanSetLegDatesChainMovesBoundarySegmentOnce` | **FAIL, exit 1** — old call 1: `0 arriving and 1 departing` (train rode Florence's end), ownership NOTE absent |
| `TestPlanSetLegDatesFinalLegExtensionMovesJourneyHome` | **PASS against old by design** (does-not-regress guard); falsified against an over-narrowed gate (origMatch disabled entirely): **FAIL, exit 1** — journey-home segment stopped moving. Restoration verified (`endOwned` gate present, vet clean) |

## Verification

- Full Go suite vs throwaway Postgres 16, serial: **1,095 top-level tests + 288 subtests, 0 failures, 2 pre-existing env-gated skips, `go test` exit 0 captured directly** (`> log 2>&1; echo EXIT=$? >> log` — never through a pipe).
- `gofmt` clean, `go vet` clean. Go-only; no wire/Flutter changes.

**Flagged, not edited** (prompt-cache budget): `plan_handler.go:549` and `:566` still say start_date moves "connecting transport" — now true only for the *into* side. Candidates for the next prompt-touching ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790338693&installation_model_id=433099&pr_number=574&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F574&signature=7e63dd31070d3a75f260c6e81a7e11d9e0615c345c480c2cc2fe4e72c4054b55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->