### PR TITLE
feat(trip-detail): desktop map row — half-width map beside the plan cards, nothing pins but the tab row

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -257,15 +257,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   // removes the leg — readers clamp via _clampedLegKey (read-side, so
   // build never mutates state).
   final ValueNotifier<String?> _focusedLegKey = ValueNotifier<String?>(null);
-  // Whether the map renders as the wide layout's pinned header (true) or the
-  // phone layout's scroll-away tap-to-expand card (false). Assigned each
-  // build from the body width; also feeds the Today-scroll chrome math.
-  bool _mapPinned = true;
   // Body-width narrow flag (< kRailBreakpoint), assigned by the root
   // LayoutBuilder in build so the APP BAR and the body agree — MediaQuery
   // would report the window, which is ~81px wider than the body when the
   // nav rail shows (window 800-880 = wide window, narrow body). Strictly
-  // < 800: the 800px test surface must stay on the desktop path.
+  // < 800: the 800px test surface must stay on the desktop path. Also the
+  // map-layout switch since the map-row redesign retired _mapPinned: wide
+  // renders the map inside the header's side-by-side row, narrow keeps the
+  // scroll-away tap-to-expand preview — the retired flag was assigned from
+  // the body LayoutBuilder, but that width and this one always agree
+  // (Scaffold adds no horizontal chrome), so one flag now carries both.
   bool _narrow = false;
   // Today mode (specs/today-mode): the itinerary auto-scrolls to today's day
   // header at most once per screen visit, and only from loud load paths.
@@ -907,18 +908,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   static const double _headerTabRowHeight =
       _listHeaderHeight - _headerTabBaseline;
 
-  /// Combined height of the chrome pinned above the itinerary slivers: the
-  /// map header (when it renders AND is pinned — on phones the map scrolls
-  /// away, so it never rests above a target header) plus the itinerary
-  /// title header. This is the resting-slot measurement for the scroll
-  /// helpers' correction passes ONLY — never subtract it from a
-  /// getOffsetToReveal result, which already accounts for these extents
+  /// Height of the chrome pinned above the itinerary slivers: the tab row
+  /// alone, at every width, since the map-row redesign scrolled the wide
+  /// map band away with the page (only the tab row still pins). This is
+  /// the resting-slot measurement for the scroll helpers' correction
+  /// passes ONLY — never subtract it from a getOffsetToReveal result,
+  /// which already accounts for these extents
   /// (`maxScrollObstructionExtentBefore`).
-  double _pinnedChrome(Trip trip) {
-    final mapShown = _derive(trip).mapShown;
-    return ((_mapPinned && mapShown) ? mapBandHeaderHeight : 0) +
-        _listHeaderHeight;
-  }
+  static const double _pinnedChrome = _listHeaderHeight;
 
   /// Measured height of the pinned city header above [dayKey]'s section
   /// (0 when it isn't laid out yet).
@@ -1080,7 +1077,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     // Header dy in viewport coordinates vs. its resting slot below the
     // pinned chrome.
     final actual = box.localToGlobal(Offset.zero, ancestor: vp).dy;
-    final delta = actual - (_pinnedChrome(trip) + _cityHeaderHeight(dayKey));
+    final delta = actual - (_pinnedChrome + _cityHeaderHeight(dayKey));
     if (delta.abs() > 2) {
       _scroll.jumpTo((_scroll.offset + delta)
           .clamp(0.0, _scroll.position.maxScrollExtent));
@@ -1157,10 +1154,19 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   }
 
   /// The combined chip action (inline strip and the full-screen map's
-  /// report-back): focus the map on the leg via [_setMapFocus], un-collapse
-  /// its group, and rest the header under the pinned map (wide layout). The
-  /// All chip (null) resets the MAP only — the list is untouched, since
-  /// expansion is decoupled from focus.
+  /// report-back): focus the map on the leg via [_setMapFocus] and
+  /// un-collapse its group. The All chip (null) resets the MAP only — the
+  /// list is untouched, since expansion is decoupled from focus.
+  ///
+  /// Deliberately NO list scroll, at any width. The inline chips ride a map
+  /// card that scrolls WITH the page everywhere since the map-row redesign,
+  /// so scrolling the list would hide the very map being focused — the
+  /// phone rationale, which wide inherited when its band stopped pinning
+  /// (the accepted tradeoff in the map-row ticket: city-header↔focus sync
+  /// loses its payoff once the map can scroll off). A selection made inside
+  /// the FULL-SCREEN map still pre-scrolls, via its own report-back — there
+  /// the list is hidden behind the modal and landing on the region is the
+  /// point.
   ///
   /// Under a bookings lens no city headers exist at all: the chip drives
   /// the map only and the lens is NOT exited (unlike _scrollToDay, whose
@@ -1170,14 +1176,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     _setMapFocus(d, key);
     if (key == null) return; // All: map overview only, list untouched
     final groupKey = d.groupKeyForLeg(key);
-    if (groupKey == null) return; // stale key: nothing to rest
+    if (groupKey == null) return; // stale key: nothing to reveal
     if (_collapsedGroups.remove(groupKey)) setState(() {});
-    // Post-frame so a freshly expanded section has laid out first (the
-    // _scrollToDay pattern); on phones the chips ride the scroll-away
-    // preview card, so scrolling the list would hide the very map being
-    // focused — desktop only.
-    if (!_mapPinned) return;
-    _revealCityHeader(groupKey);
   }
 
   /// Scrolls [groupKey]'s header under the chrome on the frame after next —
@@ -1233,7 +1233,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     final vp = RenderAbstractViewport.maybeOf(box);
     if (vp == null) return;
     final actual = box.localToGlobal(Offset.zero, ancestor: vp).dy;
-    final delta = actual - _pinnedChrome(trip);
+    final delta = actual - _pinnedChrome;
     if (delta.abs() > 2) {
       _scroll.jumpTo((_scroll.offset + delta)
           .clamp(0.0, _scroll.position.maxScrollExtent));
@@ -1286,7 +1286,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     if (!_foldControlShown(d)) return; // stale entry: no-op, never a crash
     final collapsed = _allGroupsCollapsed(d);
     // Measured BEFORE the mutation — it reads the CURRENT layout.
-    final anchor = _anchorGroupKey(trip, d);
+    final anchor = _anchorGroupKey(d);
     setState(() {
       if (collapsed) {
         _collapsedGroups.clear();
@@ -1306,10 +1306,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           ..addAll(d.groups.map((g) => g.key));
       }
     });
-    // Keep the traveler where they were. No _mapPinned guard (unlike
-    // _setFocusedLeg, which skips this on phones so the list can't scroll
-    // the just-tapped map chip out of view): no map focus is in play here,
-    // and keeping your place matters more on a phone, not less.
+    // Keep the traveler where they were, at every width (unlike
+    // _setFocusedLeg, which never scrolls so the list can't carry the
+    // just-tapped map chip out of view): no map focus is in play here, and
+    // keeping your place matters more on a phone, not less.
     if (anchor != null) _revealCityHeader(anchor, animate: false);
   }
 
@@ -1331,9 +1331,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// are SliverToBoxAdapters, open ones SliverPinnedHeaders, and neither is
   /// lazy (only the item lists INSIDE a group are) — so this needs no
   /// scroll-range heuristics and the guards below are belt-and-braces.
-  String? _anchorGroupKey(Trip trip, TripDerivation d) {
+  String? _anchorGroupKey(TripDerivation d) {
     if (!_scroll.hasClients || _scroll.offset <= 0) return null;
-    final rest = _pinnedChrome(trip) + 1; // slot + float epsilon
+    const rest = _pinnedChrome + 1; // slot + float epsilon
     String? anchor;
     var best = double.negativeInfinity;
     for (final group in d.groups) {
@@ -3582,18 +3582,20 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           initialLegKey: _clampedLegKey(derivation),
           // A full-screen chip or region-pin tap reports here: the embedded
           // card's ListenableBuilder keeps its own chips in sync live, and
-          // _setFocusedLeg pre-selects (un-collapses the target; on desktop
-          // pre-scrolls) behind the modal, so focus survives close. On
-          // phones _setFocusedLeg skips its scroll (the inline chips ride
-          // the scroll-away preview), but a selection made INSIDE the full
-          // map should land the list on that region when the modal closes —
-          // there is no visible list to disturb — so pre-scroll here too.
+          // _setFocusedLeg pre-selects (focus + un-collapse; it never
+          // scrolls — the inline chips ride a card that scrolls with the
+          // page at every width now). A selection made INSIDE the full map
+          // should land the list on that region when the modal closes —
+          // there is no visible list to disturb behind it, and with the
+          // band scrolled away the region may be anywhere — so the
+          // pre-scroll lives here, on every width (it was phone-only while
+          // the wide band pinned and _setFocusedLeg scrolled for wide).
           onLegSelected: (k) {
             final t = _trip;
             if (t == null) return;
             final d = _derive(t);
             _setFocusedLeg(d, k);
-            if (k == null || _mapPinned) return;
+            if (k == null) return;
             final groupKey = d.groupKeyForLeg(k);
             if (groupKey == null) return;
             _revealCityHeader(groupKey);
@@ -3684,8 +3686,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
 
     return LayoutBuilder(builder: (context, constraints) {
       // Same width the body LayoutBuilder sees (Scaffold adds no horizontal
-      // chrome), so this always agrees with _mapPinned. Plain assignment:
-      // we're in build, like _mapPinned's own write.
+      // chrome), so the app bar, the body and the map-layout switch all
+      // agree. Plain assignment: we're in build, and the post-frame Today
+      // scroll reads it fresh.
       _narrow = constraints.maxWidth < kRailBreakpoint;
       // Where back goes once the panel is out of the way. Null is both "opened
       // from the trips list" and every other entry point, and means the
@@ -3846,13 +3849,6 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                           }
                         });
                       }
-                      // Phones get the scroll-away tap-to-expand map; wide
-                      // layouts keep the pinned header. Keyed to the width
-                      // the body actually gets (like the refine-dock check
-                      // below), not the window. Plain assignment: we're in
-                      // build, and the post-frame Today scroll reads it
-                      // fresh.
-                      _mapPinned = constraints.maxWidth >= kRailBreakpoint;
                       // Hoisted dock decision (also used at the bottom of this
                       // builder): the docked panel and its grab strip eat this
                       // width, so the gutter must be computed from what the
@@ -3976,6 +3972,35 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                           if (mounted) _scrollToDay(pendingToday);
                         });
                       }
+                      // The one map-card recipe, shared by the wide header
+                      // row (interactive, expandable:false) and the phone
+                      // scroll-away preview (expandable:true) so the two
+                      // can never wire the map differently.
+                      Widget buildMapCard(bool expandable) =>
+                          TripDetailMapBand(
+                            trip: trip,
+                            derivation: derivation,
+                            expandable: expandable,
+                            live: _postFirstFrame,
+                            focusedLegKey: _focusedLegKey,
+                            selectedPosition: _selectedPosition,
+                            homeAirport: _homeAirport,
+                            isOffline: _isOffline,
+                            readOnly: _readOnly,
+                            segmentLabels: _mapSegmentLabels(derivation),
+                            onAddPlace: (day) => _addPlace(day: day),
+                            onRevealGroup: (groupKey) {
+                              if (_collapsedGroups.remove(groupKey)) {
+                                setState(() {});
+                              }
+                            },
+                            onRevealCityHeader: _revealCityHeader,
+                            onSetFocusedLeg: (k) =>
+                                _setFocusedLeg(derivation, k),
+                            onOpenFullMap: () => _openFullMap(trip),
+                            onShowSnack: _showSnack,
+                            clampLegKey: _clampedLegKey,
+                          );
                       final scrollView = CustomScrollView(
                         controller: _scroll,
                         // Always scrollable: with the trailing sections
@@ -3996,6 +4021,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                     isOffline: _isOffline,
                                     readOnly: _readOnly,
                                     panelOpen: _panelOpen,
+                                    // Wide: the header hosts the map beside
+                                    // the Next Step / Continue-chat cards
+                                    // (TripDetailMapRow) and the whole row
+                                    // scrolls with the page — nothing above
+                                    // the tab row pins anymore. Phones keep
+                                    // the separate preview sliver below.
+                                    mapCard:
+                                        (!_narrow && derivation.mapShown)
+                                            ? buildMapCard(false)
+                                            : null,
                                     // _fanOutWatch's condition, resolved
                                     // here because the card lives in its
                                     // own file: the review watch may run
@@ -4025,61 +4060,22 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                               ),
                             ),
                           ),
-                          // Wide: the map scrolls with the page until it
-                          // reaches the top, then stays pinned while the
-                          // itinerary scrolls beneath it. Phones have no room
-                          // to pin — a shorter static preview scrolls away
+                          // Phones: a shorter static preview scrolls away
                           // with the page, and tapping it opens the
-                          // full-screen map (TripMapScreen).
-                          if (derivation.mapShown)
+                          // full-screen map (TripMapScreen). Wide layouts
+                          // carry the map in the header row above instead.
+                          if (derivation.mapShown && _narrow)
                             tripDetailMapBandSliver(
-                              pinned: _mapPinned,
                               gutter: gutter,
-                              backgroundColor:
-                                  theme.scaffoldBackgroundColor,
-                              cardBuilder: (expandable) =>
-                                  TripDetailMapBand(
-                                trip: trip,
-                                derivation: derivation,
-                                expandable: expandable,
-                                live: _postFirstFrame,
-                                focusedLegKey: _focusedLegKey,
-                                selectedPosition: _selectedPosition,
-                                homeAirport: _homeAirport,
-                                isOffline: _isOffline,
-                                readOnly: _readOnly,
-                                segmentLabels:
-                                    _mapSegmentLabels(derivation),
-                                onAddPlace: (day) => _addPlace(day: day),
-                                onRevealGroup: (groupKey) {
-                                  if (_collapsedGroups.remove(groupKey)) {
-                                    setState(() {});
-                                  }
-                                },
-                                onRevealCityHeader: _revealCityHeader,
-                                onSetFocusedLeg: (k) =>
-                                    _setFocusedLeg(derivation, k),
-                                onOpenFullMap: () => _openFullMap(trip),
-                                onShowSnack: _showSnack,
-                                clampLegKey: _clampedLegKey,
-                              ),
-                              pinnedDelegateBuilder: (
-                                      {required height,
-                                      required backgroundColor,
-                                      required padding,
-                                      required child}) =>
-                                  _PinnedHeaderDelegate(
-                                height: height,
-                                backgroundColor: backgroundColor,
-                                padding: padding,
-                                child: child,
-                              ),
+                              child: buildMapCard(true),
                             ),
-                          // Itinerary/Bookings tab row; pins beneath the map
-                          // so the view tabs, Today jump, and the view's add
-                          // button stay reachable while scrolling. One
-                          // fixed-height row keeps the pinned chrome (and
-                          // the Today scroll math) constant.
+                          // Itinerary/Bookings tab row; the ONLY pinned
+                          // chrome at any width since the map-row redesign —
+                          // it rests under the app bar so the view tabs,
+                          // Today jump, and the view's add button stay
+                          // reachable while scrolling. One fixed-height row
+                          // keeps the pinned chrome (and the Today scroll
+                          // math) constant.
                           //
                           // It closes on a content-width hairline, and that
                           // rule is the whole point: it is the bottom edge of

--- a/src/packages/flutter-app/lib/widgets/next_step_card.dart
+++ b/src/packages/flutter-app/lib/widgets/next_step_card.dart
@@ -26,6 +26,14 @@ class NextStepCard extends StatelessWidget {
   /// width.
   final bool compact;
 
+  /// Column layouts (the wide map row's right column): the action buttons
+  /// wrap below the text instead of trailing it — at ~45% of the content
+  /// width the trailing pair would starve the title — and the card's outer
+  /// top margin is dropped, because the hosting column owns the spacing
+  /// between its stretched slots. Orthogonal to [compact]: the wide column
+  /// keeps the detail line and the Trip-health entry.
+  final bool stacked;
+
   /// Offline: the card stays visible but its actions are disabled — same
   /// treatment as the header Refine chip.
   final bool enabled;
@@ -60,6 +68,7 @@ class NextStepCard extends StatelessWidget {
     required this.step,
     this.progress,
     this.compact = false,
+    this.stacked = false,
     this.enabled = true,
     this.onPrimary,
     this.onViewAll,
@@ -186,9 +195,24 @@ class NextStepCard extends StatelessWidget {
     }
 
     final detail = s.detail;
+    // Named for where it goes. Beside a step counter, "View all" promised
+    // the steps and delivered the findings list; the sheet's own title says
+    // what this really opens.
+    final viewAllButton = (!compact && onViewAll != null)
+        ? TextButton(
+            key: const ValueKey('next-step-view-all'),
+            onPressed: enabled ? onViewAll : null,
+            child: Text(l10n.reviewSectionTitle),
+          )
+        : null;
+    final primaryButton = FilledButton.tonal(
+      key: const ValueKey('next-step-primary'),
+      onPressed: enabled ? onPrimary : null,
+      child: Text(_actionLabel(l10n)),
+    );
     return Container(
       key: const ValueKey('next-step-card'),
-      margin: const EdgeInsets.only(top: AppSpacing.md),
+      margin: stacked ? null : const EdgeInsets.only(top: AppSpacing.md),
       decoration: BoxDecoration(
         color: tintFill,
         borderRadius: AppRadius.mdAll,
@@ -208,6 +232,11 @@ class NextStepCard extends StatelessWidget {
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
+                  // min, so a stretched slot (the map row's column) centers
+                  // the text block beside the icon instead of expanding it
+                  // to the slot's full height; in the unbounded stacked
+                  // header flow this was already the laid-out size.
+                  mainAxisSize: MainAxisSize.min,
                   children: [
                     eyebrowLine,
                     const SizedBox(height: 2),
@@ -231,26 +260,32 @@ class NextStepCard extends StatelessWidget {
                         ),
                       ),
                     ],
+                    if (stacked) ...[
+                      const SizedBox(height: AppSpacing.md),
+                      // A Wrap, not a Row: the pair usually shares a line at
+                      // column width, but a long Spanish label pair drops the
+                      // primary to its own line instead of overflowing.
+                      Wrap(
+                        spacing: AppSpacing.sm,
+                        runSpacing: AppSpacing.xs,
+                        crossAxisAlignment: WrapCrossAlignment.center,
+                        children: [
+                          if (viewAllButton != null) viewAllButton,
+                          primaryButton,
+                        ],
+                      ),
+                    ],
                   ],
                 ),
               ),
-              const SizedBox(width: AppSpacing.md),
-              if (!compact && onViewAll != null) ...[
-                TextButton(
-                  key: const ValueKey('next-step-view-all'),
-                  onPressed: enabled ? onViewAll : null,
-                  // Named for where it goes. Beside a step counter, "View all"
-                  // promised the steps and delivered the findings list; the
-                  // sheet's own title says what this really opens.
-                  child: Text(l10n.reviewSectionTitle),
-                ),
-                const SizedBox(width: AppSpacing.sm),
+              if (!stacked) ...[
+                const SizedBox(width: AppSpacing.md),
+                if (viewAllButton != null) ...[
+                  viewAllButton,
+                  const SizedBox(width: AppSpacing.sm),
+                ],
+                primaryButton,
               ],
-              FilledButton.tonal(
-                key: const ValueKey('next-step-primary'),
-                onPressed: enabled ? onPrimary : null,
-                child: Text(_actionLabel(l10n)),
-              ),
             ],
           ),
         ),
@@ -263,7 +298,7 @@ class NextStepCard extends StatelessWidget {
     final detail = s.detail;
     return Container(
       key: const ValueKey('next-step-all-set'),
-      margin: const EdgeInsets.only(top: AppSpacing.md),
+      margin: stacked ? null : const EdgeInsets.only(top: AppSpacing.md),
       padding: const EdgeInsets.fromLTRB(
           AppSpacing.lg, AppSpacing.md, AppSpacing.sm, AppSpacing.md),
       decoration: BoxDecoration(
@@ -278,6 +313,8 @@ class NextStepCard extends StatelessWidget {
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
+              // min for the same stretched-slot centering as _buildStep's.
+              mainAxisSize: MainAxisSize.min,
               children: [
                 Text(
                   s.title,

--- a/src/packages/flutter-app/lib/widgets/trip_detail/map_band.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_detail/map_band.dart
@@ -1,9 +1,9 @@
 // The trip detail map band (specs/trip-detail-extract): the rounded map
-// card shared by the wide pinned header and the phone scroll-away preview,
-// plus the sliver slot that hosts them. Verbatim lift out of
-// trip_detail_screen.dart so wave 2 can redesign band height and the
-// band↔tab-bar seam without the god-screen. Zero visual, zero behavior
-// change: every screen interaction arrives as a constructor callback.
+// card shared by both layouts, plus the layout shells that host it — the
+// phone scroll-away sliver slot and the wide side-by-side map row
+// ([TripDetailMapRow], map-row redesign 2026-08-26). The band's heights and
+// row proportions live HERE; every screen interaction arrives as a
+// constructor callback.
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -17,89 +17,103 @@ import '../app_map.dart';
 import '../map_leg_chips.dart';
 import '../trip_map.dart';
 
-/// Height of the map card on the wide pinned layout (the phone layout's
-/// preview is [mapBandHeightNarrow] and scrolls away instead).
-///
-/// 280, down from 340 (wave 2, header/shell lane): this band does not scroll
-/// away — it and the tab row below it are PERMANENT chrome, so every pixel
-/// here is a pixel the itinerary never gets back. At 340 the pinned stack came
-/// to 420px and a 1000px window opened on the header, the map, the tab row and
-/// exactly one city heading, with the first day below the fold on the page
-/// whose job is the days. 280 keeps the card comfortably cinematic at the
-/// 900px content cap (~3.2:1) and leaves the map lane's own composition
-/// untouched — its chip strip insets 8 from the top and its control cluster 8
-/// from the bottom, so both still clear each other by a wide margin.
-const double _mapCardHeight = 280;
-
-/// The gap the pinned band keeps ABOVE the map card, and the one it keeps
-/// BELOW it — the band↔tab-bar seam.
-///
-/// Deliberately unequal, and that is the whole fix (wave 3). Pinned, this band
-/// sits inside a block bounded by two hairlines: the app bar's above and the
-/// tab row's below (#503 moved the selected tab's underline onto that lower
-/// rule so the tabs read as the head of the list). With 12 above and 12 below
-/// the map card read as *centred between* those two rules rather than as
-/// belonging to either, and the seam the tab row needs was indistinguishable
-/// from the sliver of scaffold under the app bar — most obviously in dark,
-/// where a bright satellite card is letterboxed by two identical strips of
-/// near-black.
-///
-/// Unequal says which way the card leans: the map hangs off the top chrome it
-/// pins with, and the larger gap below is the seam before the tab row and the
-/// list it heads. The pair still totals the same 24, so this costs the
-/// itinerary nothing and leaves #503's 420→304 argument exactly where it was.
-///
-/// The gap above is the PINNED figure only. On phones the band is not chrome —
-/// it is a card in the page flow under the header's own [AppSpacing.lg] — so
-/// that branch keeps [AppSpacing.md] above and takes only the seam below.
-const double _pinnedTopGap = AppSpacing.sm;
+/// The seam the phone band keeps below the map card, before the tab row.
 const double _seamGap = AppSpacing.lg;
 
-/// Wide pinned-header extent: top gap + map + seam. Derived from the three
-/// figures the padding below is built from, never restated, so the delegate's
-/// height and its child's insets cannot drift apart.
-const double mapBandHeaderHeight = _pinnedTopGap + _mapCardHeight + _seamGap;
+/// Minimum height of the wide layout's map card inside [TripDetailMapRow].
+///
+/// 300, up from the pinned band's 280 — and a minimum now, not an extent.
+/// The band stopped being permanent chrome (map-row redesign): it scrolls
+/// with the page, so extra height costs one scroll-through instead of a
+/// slice of every viewport, and wave 2's 340→280 argument no longer binds.
+/// At ~55% of the 900px content cap the card runs ≈1.55:1 — the approved
+/// wireframe's ≈1.6:1, the shape that fits the taller-than-wide Mercator
+/// footprint of a regional route without the old band's flanks of empty
+/// ocean. The right card column can stretch the row past this via
+/// [TripDetailMapRow]'s IntrinsicHeight, never below it.
+const double mapRowMinHeight = 300;
 
-/// Map card height on phones, where the map scrolls away instead of
-/// pinning (a preview — the full-screen map is one tap away).
+/// Map card height on phones, where the map is a scroll-away preview (the
+/// full-screen map is one tap away).
 const double mapBandHeightNarrow = 180;
 
-/// The band's sliver slot, shared by both layouts: pinned under the top
-/// chrome on wide, a fixed-height scroll-away preview on phones. The pinned
-/// branch's delegate stays the screen's own (it also pins the tab row), so
-/// it arrives as [pinnedDelegateBuilder]; the band's heights live HERE.
+/// The phone layout's band slot: a fixed-height scroll-away preview card in
+/// the page flow. Wide layouts render the map inside the header block's
+/// [TripDetailMapRow] instead — since the map-row redesign nothing above the
+/// tab row pins on any width.
 Widget tripDetailMapBandSliver({
-  required bool pinned,
   required double gutter,
-  required Color backgroundColor,
-  required Widget Function(bool expandable) cardBuilder,
-  required SliverPersistentHeaderDelegate Function({
-    required double height,
-    required Color backgroundColor,
-    required EdgeInsetsGeometry padding,
-    required Widget child,
-  }) pinnedDelegateBuilder,
+  required Widget child,
 }) {
-  if (pinned) {
-    return SliverPersistentHeader(
-      pinned: true,
-      delegate: pinnedDelegateBuilder(
-        height: mapBandHeaderHeight,
-        backgroundColor: backgroundColor,
-        padding: EdgeInsets.fromLTRB(gutter, _pinnedTopGap, gutter, _seamGap),
-        child: cardBuilder(false),
+  return SliverToBoxAdapter(
+    child: Padding(
+      // The header's own AppSpacing.lg already sits above this card, so the
+      // top gap stays md; the seam below introduces the same tab row the
+      // wide layout's row runs into.
+      padding: EdgeInsets.fromLTRB(gutter, AppSpacing.md, gutter, _seamGap),
+      child: SizedBox(height: mapBandHeightNarrow, child: child),
+    ),
+  );
+}
+
+/// The wide layout's side-by-side map row: map card left at flex 6:5 (~55%,
+/// the approved wireframe's 1.2:1), the given [cards] stacked in the right
+/// column and stretched so the column matches the map's height. With no
+/// cards (read-only trip, no saved conversation) the map spans the full
+/// content width at [mapRowMinHeight].
+///
+/// IntrinsicHeight is what makes the stretch safe: the row's height is the
+/// LARGER of [mapRowMinHeight] and the card column's own need, so a long
+/// Spanish title or a two-line preview grows the row instead of overflowing
+/// a fixed box. One extra intrinsics pass over one row — the map side
+/// reports a constant (its Stack children are all positioned), so the cost
+/// is the cards' text measurement only.
+class TripDetailMapRow extends StatelessWidget {
+  final Widget map;
+  final List<Widget> cards;
+
+  const TripDetailMapRow({
+    super.key,
+    required this.map,
+    required this.cards,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (cards.isEmpty) {
+      return SizedBox(height: mapRowMinHeight, child: map);
+    }
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Expanded(
+            flex: 6,
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(minHeight: mapRowMinHeight),
+              child: map,
+            ),
+          ),
+          const SizedBox(width: AppSpacing.md),
+          Expanded(
+            flex: 5,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // Equal flex per card (the wireframe's split): each gets the
+                // tallest card's share, so the pair reads as one block. The
+                // sm gap is the stacked layout's own next↔chat rhythm.
+                for (var i = 0; i < cards.length; i++) ...[
+                  if (i > 0) const SizedBox(height: AppSpacing.sm),
+                  Expanded(child: cards[i]),
+                ],
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }
-  return SliverToBoxAdapter(
-    child: Padding(
-      // Phone: the header's own AppSpacing.lg already sits above this card, so
-      // the top gap stays md; the seam below is the same one the pinned layout
-      // draws, because the tab row it introduces is the same tab row.
-      padding: EdgeInsets.fromLTRB(gutter, AppSpacing.md, gutter, _seamGap),
-      child: SizedBox(height: mapBandHeightNarrow, child: cardBuilder(true)),
-    ),
-  );
 }
 
 /// The rounded map card itself. When [TripDetailMapBand.expandable], the map
@@ -336,12 +350,14 @@ class TripDetailMapBand extends StatelessWidget {
         );
       },
     );
-    // Repaint-isolate the card: on the wide layout it sits pinned over the
-    // scrolling itinerary, and without a boundary its picture (card chrome +
-    // chip strip — flutter_map keeps its own internal boundary) is
-    // re-recorded every scroll frame. The boundary also keeps tap-time card
-    // rebuilds from dirtying the page layer. Inside the method so both call
-    // sites (pinned wide band, scroll-away phone card) are covered.
+    // Repaint-isolate the card: chip taps, pin selections and camera moves
+    // rebuild and repaint this subtree (card chrome + chip strip —
+    // flutter_map keeps its own internal boundary), and without a boundary
+    // each would dirty the whole page layer. The card scrolls with the page
+    // on every width now (the map-row redesign unpinned the wide band), so
+    // the old every-scroll-frame re-record is gone — the boundary stays for
+    // the tap-time isolation. Inside the method so both call sites (wide
+    // map row, scroll-away phone card) are covered.
     return RepaintBoundary(child: card);
   }
 }

--- a/src/packages/flutter-app/lib/widgets/trip_detail/trip_header_card.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_detail/trip_header_card.dart
@@ -1,8 +1,11 @@
 // The trip detail header stack (specs/trip-detail-extract): the title/meta
-// block, the Next Step card, and the Continue-chat card, lifted verbatim out
-// of trip_detail_screen.dart so wave 2 can redesign the header shell without
-// the god-screen. Screen state arrives as constructor params; actions are
-// callbacks into the screen. Pure move — zero visual, zero behavior change.
+// block, the Next Step card, and the Continue-chat card, lifted out of
+// trip_detail_screen.dart so wave 2 could redesign the header shell without
+// the god-screen. Since the map-row redesign it also hosts the wide layout's
+// side-by-side map row: this widget owns the two cards' presence logic and
+// session state, so it is the one place that can decide between the row, a
+// card-less full-width map, and the stacked phone flow. Screen state arrives
+// as constructor params; actions are callbacks into the screen.
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -16,17 +19,27 @@ import '../../utils/trip_format.dart';
 import '../next_step_card.dart';
 import '../offline_banner.dart';
 import '../plan_progress_sheet.dart';
+import 'map_band.dart';
 
-/// The header stack above the map band: title + meta chips + context line +
-/// clamped overview, then the Next Step and Continue-chat cards. Renders as
-/// one stretched column, exactly the children the screen's header sliver
-/// used to compose inline.
+/// The header stack: title + meta chips + context line + clamped overview,
+/// then the Next Step and Continue-chat cards — beside the map in the wide
+/// layout's [TripDetailMapRow] when [mapCard] is set, stacked full-width
+/// below the header block otherwise. Renders as one stretched column.
 class TripHeaderCard extends ConsumerStatefulWidget {
   final Trip trip;
   final bool narrow;
   final bool isOffline;
   final bool readOnly;
   final bool panelOpen;
+
+  /// The wide layout's inline map card, pre-built by the screen (it owns
+  /// every callback and notifier the map needs). Non-null only when the
+  /// layout is wide AND the trip has mappable content; the phone preview
+  /// stays a separate scroll-away sliver below the header, so this widget
+  /// never sees it. When set, the Next Step and Continue-chat cards move
+  /// into the map row's right column; when both are absent the map spans
+  /// the full content width ([TripDetailMapRow]'s own degenerate case).
+  final Widget? mapCard;
 
   /// Whether the Next Step card's trip-review watch may run this frame.
   /// False only during the screen's deferred first content frame, and only
@@ -62,6 +75,7 @@ class TripHeaderCard extends ConsumerStatefulWidget {
     required this.isOffline,
     required this.readOnly,
     required this.panelOpen,
+    this.mapCard,
     required this.reviewLive,
     required this.displayTitle,
     this.titleKey,
@@ -90,14 +104,53 @@ class _TripHeaderCardState extends ConsumerState<TripHeaderCard> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = context.l10n;
+    final mapCard = widget.mapCard;
+    if (mapCard == null) {
+      // Phone flow, and wide trips with nothing to map: the pre-map-row
+      // stacked layout, byte-identical.
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _headerCard(theme),
+          _nextStepArea(),
+          _continueChatRow(theme, l10n),
+        ],
+      );
+    }
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         _headerCard(theme),
-        _nextStepArea(),
-        _continueChatRow(theme, l10n),
+        const SizedBox(height: AppSpacing.lg),
+        // The Consumer scopes the review watch to the row, exactly as
+        // _nextStepArea scopes it in the stacked flow: a review update
+        // rebuilds the row, and the pre-built [TripHeaderCard.mapCard]
+        // instance is identical across those rebuilds, so the map subtree
+        // is skipped. The row must own the watch because the Next Step
+        // card's PRESENCE is layout here — with neither card the map takes
+        // the full content width.
+        Consumer(builder: (context, ref, _) {
+          final next = _resolveNextStep(ref);
+          return TripDetailMapRow(
+            map: mapCard,
+            cards: [
+              if (next != null) _nextStepCard(next, stacked: true),
+              if (_chatRowShown) _continueChatRow(theme, l10n, inRow: true),
+            ],
+          );
+        }),
       ],
     );
+  }
+
+  /// Whether the Continue-chat row renders — [_continueChatRow]'s own gate,
+  /// named so the wide map row can make it a layout decision.
+  bool get _chatRowShown {
+    final trip = widget.trip;
+    return trip.refineChat != null &&
+        !widget.panelOpen &&
+        trip.canEdit &&
+        !widget.isOffline;
   }
 
   Widget _headerCard(ThemeData theme) {
@@ -278,49 +331,69 @@ class _TripHeaderCardState extends ConsumerState<TripHeaderCard> {
     );
   }
 
-  Widget _nextStepArea() {
-    final trip = widget.trip;
-    if (widget.readOnly) return const SizedBox.shrink();
+  /// What the Next Step area shows, or null when it shows nothing — the ONE
+  /// presence rule, shared by the stacked flow and the wide map row (where
+  /// null is also a layout fact: no right-column slot). Must be called with
+  /// an enclosing [Consumer]'s ref so review updates rebuild that subtree
+  /// only. Owns the "session saw a real step" post-frame write.
+  ({NextStep step, PlanProgress? progress})? _resolveNextStep(WidgetRef ref) {
+    if (widget.readOnly) return null;
     // Deferred first frame (see [TripHeaderCard.reviewLive]): don't create
     // the review fetch yet — identical render to the unresolved watch.
-    if (!widget.reviewLive) return const SizedBox.shrink();
+    if (!widget.reviewLive) return null;
+    final review = ref
+        .watch(tripReviewProvider(TripReviewKey(widget.trip.id)))
+        .valueOrNull;
+    final step = review?.nextStep;
+    if (step == null) return null;
+    final allSet = step.kind == 'all_set';
+    if (!allSet && !_hadNextStep) {
+      // Record "this session saw a real step" post-frame (no setState in
+      // build); the guard makes it one-shot.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && !_hadNextStep) setState(() => _hadNextStep = true);
+      });
+    }
+    if (allSet && (!_hadNextStep || _allSetDismissed)) return null;
+    return (step: step, progress: review?.planProgress);
+  }
+
+  /// The Next Step card for a resolved step — construction shared by both
+  /// layouts so they can never disagree about wiring; only [stacked]
+  /// (buttons below the text, no outer margin) differs in the map row.
+  Widget _nextStepCard(({NextStep step, PlanProgress? progress}) next,
+      {bool stacked = false}) {
+    final step = next.step;
+    final progress = next.progress;
+    final allSet = step.kind == 'all_set';
+    return NextStepCard(
+      step: step,
+      progress: progress,
+      compact: widget.narrow,
+      stacked: stacked,
+      enabled: !widget.isOffline,
+      // Same lookup the tap performs, so the label can never promise a
+      // handoff the action won't make (specs/next-step-cta).
+      transportHandsOff: widget.transportHandsOff(step),
+      onPrimary: allSet ? null : () => widget.onNextStepAction(step),
+      onViewAll: () => widget.onOpenHealthSheet(),
+      // No ladder on the wire (older server, cached response) => no
+      // affordance, rather than an entry point onto an empty sheet.
+      onViewProgress: progress != null && progress.phases.isNotEmpty
+          ? () => showPlanProgressSheet(context,
+              progress: progress, currentStep: step)
+          : null,
+      onDismiss:
+          allSet ? () => setState(() => _allSetDismissed = true) : null,
+    );
+  }
+
+  Widget _nextStepArea() {
     return Consumer(
       builder: (context, ref, _) {
-        final review =
-            ref.watch(tripReviewProvider(TripReviewKey(trip.id))).valueOrNull;
-        final step = review?.nextStep;
-        if (step == null) return const SizedBox.shrink();
-        final allSet = step.kind == 'all_set';
-        if (!allSet && !_hadNextStep) {
-          // Record "this session saw a real step" post-frame (no setState in
-          // build); the guard makes it one-shot.
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (mounted && !_hadNextStep) setState(() => _hadNextStep = true);
-          });
-        }
-        if (allSet && (!_hadNextStep || _allSetDismissed)) {
-          return const SizedBox.shrink();
-        }
-        final progress = review?.planProgress;
-        return NextStepCard(
-          step: step,
-          progress: progress,
-          compact: widget.narrow,
-          enabled: !widget.isOffline,
-          // Same lookup the tap performs, so the label can never promise a
-          // handoff the action won't make (specs/next-step-cta).
-          transportHandsOff: widget.transportHandsOff(step),
-          onPrimary: allSet ? null : () => widget.onNextStepAction(step),
-          onViewAll: () => widget.onOpenHealthSheet(),
-          // No ladder on the wire (older server, cached response) => no
-          // affordance, rather than an entry point onto an empty sheet.
-          onViewProgress: progress != null && progress.phases.isNotEmpty
-              ? () => showPlanProgressSheet(context,
-                  progress: progress, currentStep: step)
-              : null,
-          onDismiss:
-              allSet ? () => setState(() => _allSetDismissed = true) : null,
-        );
+        final next = _resolveNextStep(ref);
+        if (next == null) return const SizedBox.shrink();
+        return _nextStepCard(next);
       },
     );
   }
@@ -346,13 +419,15 @@ class _TripHeaderCardState extends ConsumerState<TripHeaderCard> {
   /// rationale: these are two jobs — "what to do next" and "where you left
   /// off" — and one tinted field would give the quieter one the emphasis of
   /// the louder. Sequence, not fusion.
-  Widget _continueChatRow(ThemeData theme, AppLocalizations l10n) {
+  ///
+  /// [inRow] — the wide map row's column slot: the top margin is dropped
+  /// (the column owns spacing between its stretched slots), nothing else.
+  Widget _continueChatRow(ThemeData theme, AppLocalizations l10n,
+      {bool inRow = false}) {
     final trip = widget.trip;
     final chat = trip.refineChat;
-    if (chat == null || widget.panelOpen || !trip.canEdit || widget.isOffline) {
-      return const SizedBox.shrink();
-    }
-    final updated = DateTime.tryParse(chat.updatedAt);
+    if (!_chatRowShown) return const SizedBox.shrink();
+    final updated = DateTime.tryParse(chat!.updatedAt);
     // relativeTime already exists (offline_banner.dart) — reuse it rather than
     // growing a second "how long ago" rule.
     final meta = updated == null
@@ -366,7 +441,7 @@ class _TripHeaderCardState extends ConsumerState<TripHeaderCard> {
       // several PopupMenuButton<String>s, and scoping to this row's structure
       // is what broke when the row stopped being a ListTile.
       key: const ValueKey('continue-chat-row'),
-      margin: const EdgeInsets.only(top: AppSpacing.sm),
+      margin: inRow ? null : const EdgeInsets.only(top: AppSpacing.sm),
       decoration: BoxDecoration(
         color: theme.colorScheme.surfaceContainerHigh,
         borderRadius: AppRadius.mdAll,
@@ -387,6 +462,10 @@ class _TripHeaderCardState extends ConsumerState<TripHeaderCard> {
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
+                  // min, so the map row's stretched column slot centers the
+                  // text block instead of expanding it; identical layout in
+                  // the unbounded stacked flow.
+                  mainAxisSize: MainAxisSize.min,
                   children: [
                     // Title and meta share a line via a Wrap: on a phone (or in
                     // Spanish, where both strings are longer) the counter drops

--- a/src/packages/flutter-app/test/trip_detail_all_expanded_headers_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_all_expanded_headers_test.dart
@@ -9,7 +9,6 @@ import 'package:travel_route_planner/services/api_client.dart';
 import 'package:travel_route_planner/services/trips_api_service.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
-import 'package:travel_route_planner/widgets/trip_detail/map_band.dart';
 import 'package:travel_route_planner/widgets/trip_map.dart';
 
 import 'support/city_groups.dart';
@@ -23,7 +22,8 @@ import 'support/l10n_test_app.dart';
 //   * while scrolling, exactly ONE city header obstructs at a time: each
 //     group's containing MultiSliver pushes its own header off at the
 //     group's end, so consecutive headers hand off edge-to-edge and the
-//     pinned slot ([_pinnedSlot]: the map band plus the tab row) never
+//     pinned slot ([_pinnedSlot]: the tab row — the only pinned chrome
+//     since the map-row redesign scrolled the band away) never
 //     accumulates obstruction as more groups pin and unpin;
 //   * header taps are pure list toggles — the map-side assertions live in
 //     trip_detail_leg_focus_test.dart; here they only pin down that N
@@ -130,7 +130,7 @@ double _headerTop(WidgetTester tester, String city) =>
 
 /// The scroll offset that rests [city]'s header in the pinned slot —
 /// getOffsetToReveal at alignment 0, which already subtracts the pinned
-/// map band + tab row (maxScrollObstructionExtentBefore). City headers are
+/// tab row (maxScrollObstructionExtentBefore). City headers are
 /// SliverPinnedHeader children, always built, so this works at any offset;
 /// accuracy depends on how much of the intervening item batches is built.
 double _reveal(WidgetTester tester, String city) {
@@ -152,24 +152,23 @@ double _viewportTop(WidgetTester tester) =>
     tester.getBottomLeft(find.byType(AppBar)).dy;
 
 /// The screen's own pinned tab-row extent (`_listHeaderHeight`, private to
-/// the screen). Restated, not derived — but paired with [mapBandHeaderHeight]
-/// below so the half of this sum that DOES move with a redesign is read from
-/// its source. It was a bare `420` until the wave-2 header lane retuned the
-/// band, which failed these two tests by exactly the 60px it removed.
+/// the screen). The `mapBandHeaderHeight` term this was once paired with is
+/// gone WITH the constant: since the map-row redesign the band scrolls away
+/// with the page at every width and only the tab row still pins.
 const double _tabRowHeight = 56;
 
-/// Where a pinned city header comes to rest: below the map band and the tab
-/// row, in viewport coordinates.
+/// Where a pinned city header comes to rest: below the tab row, in viewport
+/// coordinates.
 double _pinnedSlot(WidgetTester tester) =>
-    _viewportTop(tester) + mapBandHeaderHeight + _tabRowHeight;
+    _viewportTop(tester) + _tabRowHeight;
 
 void main() {
   testWidgets('exactly one city header pins; the next city pushes it off',
       (tester) async {
-    // Tall surface: the pinned map band pushes deep-group geometry
-    // below an 800px fold. Berlin's six days keep enough trailing extent
-    // (item tiles are ~58px) that a mid-group-3 offset stays reachable on
-    // the ~1724px content viewport.
+    // Tall surface: the header block and its in-flow map row push
+    // deep-group geometry below an 800px fold. Berlin's six days keep
+    // enough trailing extent (item tiles are ~58px) that a mid-group-3
+    // offset stays reachable on the tall content viewport.
     _useSurface(tester, const Size(1200, 2200));
     await _pump(tester, _trip(perDay: 6, berlinDays: 6));
 
@@ -186,7 +185,7 @@ void main() {
 
     final slotDy = _headerTop(tester, 'Rome');
     expect((slotDy - slot).abs(), lessThanOrEqualTo(2),
-        reason: 'Rome header should pin below map band + tab row');
+        reason: 'Rome header should pin below the tab row');
     // Paris — the previous group's header — has been pushed fully off the
     // slot (its own MultiSliver's end carried it up), not stacked above it.
     expect(_headerTop(tester, 'Paris'), lessThanOrEqualTo(slotDy - headerH + 2),
@@ -290,6 +289,19 @@ void main() {
     await _pump(tester, _trip(perDay: 6, berlinDays: 6));
     final position = _position(tester);
 
+    // Capture the region-pin callback WHILE the inline map is mounted: the
+    // band scrolls with the page now (map-row redesign), so at the bottom
+    // the card is unbuilt and there is no pin to tap. The scroll math this
+    // probe guards (_revealCityHeader → estimated-offset animate + one
+    // correction) is offset-independent and shared with the Today jump, so
+    // invoking the captured callback from the bottom keeps the
+    // estimation-regime coverage without inventing a surface that no
+    // longer exists there.
+    final map = _map(tester);
+    expect(map.onDestinationTap, isNotNull,
+        reason: 'the desktop inline card wires destination-pin navigation');
+    final destinationTap = map.onDestinationTap!;
+
     // Park at the very bottom. Twice: the first jump can shift
     // maxScrollExtent as SliverList estimates correct against built
     // children; the second lands on the settled value.
@@ -306,13 +318,9 @@ void main() {
         reason: 'premise: city-1 items must be unbuilt for the probe to '
             'exercise offset estimation');
 
-    // Region-pin tap for city 1 on the inline All-overview map, invoked
-    // directly (the robust pattern at the screen level). No settle: the
+    // Region-pin tap for city 1, via the captured callback. No settle: the
     // whole point is to watch the motion.
-    final map = _map(tester);
-    expect(map.onDestinationTap, isNotNull,
-        reason: 'the desktop inline card wires destination-pin navigation');
-    map.onDestinationTap!('Paris');
+    destinationTap('Paris');
 
     // Sample the scroll frame by frame across the 350ms animation plus the
     // one-jump correction pass.
@@ -339,9 +347,13 @@ void main() {
     // And it lands exactly: city 1's header rests in the pinned slot.
     final slot = _pinnedSlot(tester);
     expect((_headerTop(tester, 'Paris') - slot).abs(), lessThanOrEqualTo(2),
-        reason: 'Paris header should rest below map band + tab row');
+        reason: 'Paris header should rest below the tab row');
     // The navigation was list-only: no focus write, camera untouched, the
-    // destination pins still render.
+    // destination pins still render. Read back at the top — the landed
+    // offset can leave the in-flow map row unbuilt, and focus state lives
+    // in notifiers, so it survives the card's unmount either way.
+    position.jumpTo(0);
+    await tester.pumpAndSettle();
     expect(_map(tester).fitSignature, isNull,
         reason: 'a destination-pin tap must not write map focus');
     expect(_map(tester).destinations, isNotNull,

--- a/src/packages/flutter-app/test/trip_detail_leg_focus_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_leg_focus_test.dart
@@ -9,26 +9,28 @@ import 'package:travel_route_planner/services/trips_api_service.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 import 'package:travel_route_planner/widgets/map_leg_chips.dart';
-import 'package:travel_route_planner/widgets/trip_detail/map_band.dart';
 import 'package:travel_route_planner/widgets/trip_map.dart';
 
 import 'support/chip_finders.dart';
 import 'support/city_groups.dart';
 import 'support/l10n_test_app.dart';
 
-// The map/list decoupling contract (specs/map-city-focus, decoupled rev):
+// The map/list decoupling contract (specs/map-city-focus, decoupled rev;
+// scroll semantics per the map-row redesign, which unpinned the wide band):
 //   * city groups default EXPANDED; expansion is list-only state
 //     (_collapsedGroups) — a header tap is a pure toggle of that ONE group:
 //     it never writes map focus, never moves the camera, never touches
 //     other groups;
 //   * map focus (_focusedLegKey) is MAP-only state: a chip tap focuses the
-//     leg, un-collapses its group, and on the wide layout rests the city
-//     header just below the pinned chrome; phones never scroll. The All
-//     chip resets the MAP only — the list is untouched;
+//     leg and un-collapses its group, and NEVER scrolls the list — at any
+//     width, the chips ride a map card that scrolls with the page, so a
+//     scroll would carry the just-focused map away (the accepted tradeoff
+//     in the map-row ticket). The All chip resets the MAP only;
 //   * a map pin tap reveals its run in the list WITHOUT moving the camera
 //     (reveal-only), and a focus change clears the map pin selection;
 //   * a destination (region) pin tap on the All overview scrolls the list
-//     to the region's group — no focus write, the camera never moves;
+//     to the region's group — an explicit "take me there" — with no focus
+//     write; the camera never moves;
 //   * bookings lenses (no city headers) get map-only chips, lens kept;
 //   * revisited cities focus per RUN key; single-leg trips have no focus.
 
@@ -115,8 +117,7 @@ Future<void> _tapChip(WidgetTester tester, String label) async {
     of: find.byType(MapLegChips),
     matching: find.text(label),
   ));
-  // Settles the post-frame camera re-fit and (desktop) the 350ms page
-  // scroll to the focused city header.
+  // Settles the post-frame camera re-fit (chip taps never scroll the page).
   await tester.pumpAndSettle();
 }
 
@@ -130,18 +131,16 @@ void _useSurface(WidgetTester tester, Size size) {
 }
 
 /// The screen's own pinned tab-row extent (`_listHeaderHeight`, private to
-/// the screen); [mapBandHeaderHeight] is read from its source so a band
-/// retune can't silently invalidate this math again. These three assertions
-/// carried a bare `420` until the wave-2 header lane shortened the band.
+/// the screen) — since the map-row redesign the ONLY chrome above a resting
+/// header: the map band scrolls with the page at every width now, so the
+/// old `mapBandHeaderHeight` term (and the constant itself) is gone.
 const double _tabRowHeight = 56;
 
-/// Where a city header comes to rest: below the pinned map band and tab row,
-/// measured from the viewport top (the app bar's bottom — the scroll math
-/// lives in viewport coordinates).
+/// Where a city header comes to rest: below the pinned tab row, measured
+/// from the viewport top (the app bar's bottom — the scroll math lives in
+/// viewport coordinates).
 double _pinnedSlot(WidgetTester tester) =>
-    tester.getBottomLeft(find.byType(AppBar)).dy +
-    mapBandHeaderHeight +
-    _tabRowHeight;
+    tester.getBottomLeft(find.byType(AppBar)).dy + _tabRowHeight;
 
 void main() {
   testWidgets(
@@ -180,94 +179,58 @@ void main() {
   });
 
   testWidgets(
-      'desktop chip tap rests the city header just below the pinned chrome',
-      (tester) async {
+      'wide chip tap focuses the map without scrolling the list '
+      '(the band scrolls with the page — the map-row tradeoff)', (tester) async {
     _useSurface(tester, const Size(1200, 800));
     await _pump(tester, _threeCityTrip());
 
-    await _tapChip(tester, 'Rome');
-
-    expect(_map(tester).fitSignature, 'Rome');
-    // The group's items are reachable (expanded — the landing default; the
-    // chip tap re-opens a manually collapsed group)…
-    expect(find.text('Roman Forum 0'), findsOneWidget);
-    // …and its header rests right below the pinned chrome (see [_pinnedSlot]).
-    // The one correction pass tolerates ±2.
-    final slot = _pinnedSlot(tester);
-    final headerTop = tester
-        .getTopLeft(find
-            .ancestor(
-                of: cityHeaderLabel('Rome'), matching: find.byType(Material))
-            .first)
-        .dy;
-    expect((headerTop - slot).abs(), lessThanOrEqualTo(2),
-        reason: 'Rome header should rest below map band + tab row');
-  });
-
-  testWidgets(
-      'chip tap scrolls straight to the target: no up-then-down reversal',
-      (tester) async {
-    _useSurface(tester, const Size(1200, 800));
-    await _pump(tester, _threeCityTrip());
-
-    // Focus Rome, then park at the very bottom (every group lands expanded,
-    // so the 8 Rome items give plenty of scroll extent). The regression
-    // only shows on a net-upward scroll: from the top the buggy motion
-    // (animate clamped at ~0, one down-snap) was still monotone and the
-    // resting assert above passed all along.
-    await _tapChip(tester, 'Rome');
     final scrollable = find
         .descendant(
             of: find.byType(CustomScrollView),
             matching: find.byType(Scrollable))
         .first;
     final position = tester.state<ScrollableState>(scrollable).position;
-    position.jumpTo(position.maxScrollExtent);
-    await tester.pumpAndSettle();
-    final start = position.pixels;
+    expect(position.maxScrollExtent, greaterThan(0),
+        reason: 'premise: the page must have somewhere to scroll — '
+            'otherwise "did not scroll" is vacuous');
+    expect(position.pixels, 0);
 
-    // Tap Paris WITHOUT settling, then sample the scroll frame by frame:
-    // double-subtracting the pinned chrome animated a full chrome height
-    // past the target
-    // and let the correction pass snap back down — a direction reversal
-    // mid-gesture.
-    await tester.tap(find.descendant(
-        of: find.byType(MapLegChips), matching: find.text('Paris')));
-    final samples = <double>[];
-    for (var i = 0; i < 12; i++) {
-      await tester.pump(const Duration(milliseconds: 50));
-      samples.add(position.pixels);
-    }
-    await tester.pumpAndSettle();
-    samples.add(position.pixels);
+    await _tapChip(tester, 'Rome');
 
-    expect(samples.last, lessThan(start),
-        reason: 'premise: the Paris rest offset must sit above the parked '
-            'bottom position — otherwise this scenario went vacuous');
-    var maxRise = 0.0;
-    for (var i = 1; i < samples.length; i++) {
-      final rise = samples[i] - samples[i - 1];
-      if (rise > maxRise) maxRise = rise;
-    }
-    expect(maxRise, lessThanOrEqualTo(2),
-        reason: 'a net-upward scroll must never move back down '
-            '(up-then-down jank); from $start: $samples');
+    expect(_map(tester).fitSignature, 'Rome');
+    // The page did not move: wide adopted the phone's unpinned semantics
+    // when the band stopped pinning — a scroll here would carry the
+    // just-focused map (and the chip under the pointer) off screen. The
+    // full-screen map's report-back is where selection still pre-scrolls
+    // (trip_detail_map_expand_test).
+    expect(position.pixels, 0);
+  });
 
-    // And it still lands exactly: Paris rests below the pinned chrome.
-    final slot = _pinnedSlot(tester);
-    final headerTop = tester
-        .getTopLeft(find
-            .ancestor(
-                of: cityHeaderLabel('Paris'), matching: find.byType(Material))
-            .first)
-        .dy;
-    expect((headerTop - slot).abs(), lessThanOrEqualTo(2),
-        reason: 'Paris header should rest below map band + tab row');
+  testWidgets('a chip tap still re-opens its collapsed group (no scroll)',
+      (tester) async {
+    // Tall surface so every header is tappable without scrolling — the
+    // scroll-suppression half lives in the 800px test above, where the page
+    // actually has extent.
+    _useSurface(tester, const Size(1200, 2200));
+    await _pump(tester, _threeCityTrip());
+
+    await collapseCity(tester, 'Rome');
+    expect(find.text('Roman Forum 0'), findsNothing);
+
+    await _tapChip(tester, 'Rome');
+
+    expect(_map(tester).fitSignature, 'Rome');
+    expect(find.text('Roman Forum 0'), findsOneWidget,
+        reason: 'a chip tap must still re-open its collapsed group');
   });
 
   testWidgets('the map reset resets the map only: the list is untouched',
       (tester) async {
-    _useSurface(tester, const Size(1200, 800));
+    // Tall surface: with the map row in the page flow (nothing pins above
+    // the tab row anymore) and chip taps no longer scrolling, Rome's tiles
+    // must fit on screen at rest for the list-untouched assertions to see
+    // them build.
+    _useSurface(tester, const Size(1200, 2200));
     await _pump(tester, _threeCityTrip());
 
     expect(mapResetButton, findsNothing,
@@ -351,10 +314,13 @@ void main() {
       'a destination pin tap scrolls to the region without touching the map',
       (tester) async {
     // Tall enough that Rome's header sits above the fold for the collapse
-    // tap, short enough that the fixture still has the ~425px of scroll
-    // extent the rest-below-chrome assertion needs (a 2200 surface
-    // swallows the whole trip: maxScrollExtent 0, nothing can scroll).
-    _useSurface(tester, const Size(1200, 1100));
+    // tap, short enough that the fixture still has the scroll extent the
+    // rest-below-chrome assertion needs (a 2200 surface swallows the whole
+    // trip: maxScrollExtent 0, nothing can scroll). 900 rather than the
+    // old 1100: the in-flow map row moved Rome's reveal offset ~300 lower,
+    // and at 1100 the scroll clamped at maxScrollExtent ~134px short of
+    // the slot.
+    _useSurface(tester, const Size(1200, 900));
     await _pump(tester, _threeCityTrip());
 
     await collapseCity(tester, 'Rome');
@@ -371,8 +337,8 @@ void main() {
 
     expect(find.text('Roman Forum 0'), findsOneWidget,
         reason: 'the region tap re-opens its collapsed group');
-    // Same rest math as a chip tap: map band + tab row, ±2 for the
-    // one correction pass.
+    // The rest slot is the pinned tab row alone (the band scrolled away
+    // with the page), ±2 for the one correction pass.
     final slot = _pinnedSlot(tester);
     final headerTop = tester
         .getTopLeft(find
@@ -381,7 +347,7 @@ void main() {
             .first)
         .dy;
     expect((headerTop - slot).abs(), lessThanOrEqualTo(2),
-        reason: 'Rome header should rest below map band + tab row');
+        reason: 'Rome header should rest below the pinned tab row');
     final position = tester
         .state<ScrollableState>(find
             .descendant(
@@ -390,6 +356,11 @@ void main() {
             .first)
         .position;
     expect(position.pixels, greaterThan(0));
+    // The landed page has scrolled the in-flow map row out of the build —
+    // return to the top to read the map's state (focus lives in notifiers,
+    // so it survives the card unmounting).
+    position.jumpTo(0);
+    await tester.pumpAndSettle();
     expect(_map(tester).fitSignature, isNull,
         reason: 'a region tap never moves the camera');
   });

--- a/src/packages/flutter-app/test/trip_detail_map_expand_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_map_expand_test.dart
@@ -174,20 +174,58 @@ void main() {
     expect(inlineMap.items.map((i) => i.name), ['Colosseum']);
   });
 
-  testWidgets('wide: map keeps the pinned interactive treatment',
+  testWidgets(
+      'wide: the inline map is fully interactive and scrolls away with the '
+      'page (map-row redesign — nothing above the tab row pins)',
       (WidgetTester tester) async {
     await pumpScreen(tester, surface: const Size(1200, 800));
 
     // Interactive inline: zoom controls present, plus the fullscreen control
-    // in the map's own strip (the full-screen map used to be unreachable at
-    // wide widths).
+    // in the map's own strip — the wide map is NOT the phone's
+    // pointer-absorbing tap-to-expand preview, even though it now scrolls
+    // like one.
     expect(inMap(find.byIcon(Icons.add)), findsOneWidget);
     expect(inMap(find.byIcon(Icons.fullscreen)), findsOneWidget);
 
-    // Pinned: scrolling the page leaves the map in the viewport.
-    await tester.drag(find.byType(CustomScrollView), const Offset(0, -400));
-    await tester.pump();
-    expect(find.byType(TripMap), findsOneWidget);
+    // Unpinned: a page scroll carries the map up and off. Driven through
+    // the position, not a drag — a drag STARTING ON an interactive map pans
+    // the map, and this fixture's row leaves little drag room beside it.
+    final mapTopBefore = tester.getTopLeft(find.byType(TripMap)).dy;
+    final position = pagePosition(tester);
+    position.jumpTo(position.maxScrollExtent);
+    await tester.pumpAndSettle();
+    final mapAfter = find.byType(TripMap);
+    if (mapAfter.evaluate().isEmpty) {
+      // Scrolled fully out and unmounted — the strongest form of "not
+      // pinned".
+    } else {
+      expect(tester.getTopLeft(mapAfter).dy, lessThan(mapTopBefore),
+          reason: 'the map must move with the page, not hold a pinned slot');
+    }
+    // The tab row is the chrome that stays: its view tabs are still up.
+    expect(find.text('Itinerary'), findsOneWidget);
+  });
+
+  testWidgets(
+      'wide: a leg picked in the full-screen map pre-scrolls the list '
+      'behind the modal (the phone report-back, now at every width)',
+      (WidgetTester tester) async {
+    await pumpScreen(tester, surface: const Size(1200, 800));
+
+    await tester.tap(inMap(find.byIcon(Icons.fullscreen)));
+    await tester.pumpAndSettle();
+    expect(find.byType(TripMapScreen), findsOneWidget);
+
+    await tapChip(tester, 'Rome');
+    await tester.tap(find.byType(CloseButton));
+    await tester.pumpAndSettle();
+
+    // With the band scrolled away rather than pinned, the modal's chip tap
+    // needs the pre-scroll exactly as phones do: closing must land the
+    // list on Rome, not back at the top of the page.
+    expect(find.byType(TripMapScreen), findsNothing);
+    expect(pagePosition(tester).pixels, greaterThan(0),
+        reason: 'the report-back must pre-scroll the wide list too');
   });
 
   testWidgets(
@@ -208,19 +246,28 @@ void main() {
     await tester.tap(find.byType(CloseButton));
     await tester.pumpAndSettle();
 
-    // Back on the trip screen, the inline chips kept the focus AND the
-    // report-back pre-scrolled Rome's header into place behind the modal
-    // (expansion is decoupled from focus: no group collapses, the
-    // selection just lands in view on close).
+    // Back on the trip screen, the focus survived the round trip. The
+    // report-back pre-scrolled the page to Rome behind the modal (pinned
+    // by the pre-scroll test above), which carries the in-flow map row out
+    // of the viewport — the phone situation exactly — so scroll back up to
+    // read the inline chips, as the phone tests do.
     expect(find.byType(TripMapScreen), findsNothing);
+    pagePosition(tester).jumpTo(0);
+    await tester.pumpAndSettle();
     final inlineChips = tester.widget<MapLegChips>(find.byType(MapLegChips));
     expect(inlineChips.selected, 'Rome');
-    expect(find.text('Colosseum'), findsOneWidget);
+    final inlineMap = tester.widget<TripMap>(find.byType(TripMap));
+    expect(inlineMap.items.map((i) => i.name), ['Colosseum'],
+        reason: 'the inline card must come back up already leg-filtered');
   });
 
   testWidgets('wide: the full-screen map reset resets the map only',
       (WidgetTester tester) async {
-    await pumpScreen(tester, surface: const Size(1200, 800));
+    // Tall enough that the whole fixture fits: the reset itself never
+    // scrolls, and keeping every tile built lets the list-untouched assert
+    // read Rome's row directly (with the band in page flow, an 800px
+    // surface leaves Rome's tiles unbuilt below the fold).
+    await pumpScreen(tester, surface: const Size(1200, 1600));
 
     await tester.tap(inMap(find.byIcon(Icons.fullscreen)));
     await tester.pumpAndSettle();
@@ -232,6 +279,11 @@ void main() {
     await tester.tap(find.byType(CloseButton));
     await tester.pumpAndSettle();
 
+    // The chip tap's pre-scroll behind the modal may have moved the page
+    // (whatever extent this surface leaves) — return to the top before
+    // reading the inline card, the phone tests' own pattern.
+    pagePosition(tester).jumpTo(0);
+    await tester.pumpAndSettle();
     final inlineChips = tester.widget<MapLegChips>(find.byType(MapLegChips));
     expect(inlineChips.selected, isNull);
     final inlineMap = tester.widget<TripMap>(find.byType(TripMap));

--- a/src/packages/flutter-app/test/trip_detail_map_row_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_map_row_test.dart
@@ -1,0 +1,268 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/trip_refine_chat.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/trip_finding.dart';
+import 'package:travel_route_planner/providers/trip_review_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trip_review_api_service.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/widgets/trip_map.dart';
+
+import 'support/l10n_test_app.dart';
+
+// The wide map row (map-row redesign, 2026-08-26): inside the content cap
+// the map card sits LEFT at ~55% with the Next Step and Continue-chat cards
+// stacked beside it, the whole row scrolls away with the page, and only the
+// tab row still pins. With neither card (read-only / no conversation /
+// review empty) the map spans the full content width. The narrow layout is
+// untouched: the scroll-away preview card survives byte-for-byte.
+//
+// All assertions are structural or geometric relations between widget
+// rects — never rendered-text sizes (the widget-test font is not Inter).
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+class _FakeReviewApiService extends TripReviewApiService {
+  final TripReview review;
+  _FakeReviewApiService(this.review) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<TripReview> getReview(String tripId, {bool checkHours = false}) async =>
+      review;
+}
+
+ItineraryItem _item(
+  int pos,
+  String name,
+  String city,
+  double lat,
+  double lng,
+  int day,
+) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      latitude: lat,
+      longitude: lng,
+      category: 'attraction',
+      day: day,
+      city: city,
+    );
+
+/// Two geocoded cities (the leg strip renders) with enough Rome stops that
+/// the page has real scroll extent at 800px tall.
+Trip _trip({TripRefineChat? chat}) => Trip(
+      id: 't1',
+      title: 'Grand tour',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      startDate: '2026-09-01',
+      endDate: '2026-09-05',
+      refineChat: chat,
+      items: [
+        _item(0, 'Louvre', 'Paris', 48.8606, 2.3376, 1),
+        _item(1, 'Orsay', 'Paris', 48.8600, 2.3266, 2),
+        for (var k = 0; k < 8; k++)
+          _item(2 + k, 'Roman Forum $k', 'Rome', 41.89 + k * 0.001, 12.49, 3),
+      ],
+    );
+
+const _lodgingReview = TripReview(
+  findings: [],
+  nextStep: NextStep(
+    kind: 'add_lodging',
+    title: 'Book a place to stay',
+    detail: '2 unbooked nights in Rome',
+    seedPrompt: 'Help me find lodging.',
+  ),
+  planProgress: PlanProgress(done: 2, total: 6),
+);
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required Trip trip,
+  required TripReview review,
+  required Size surface,
+}) async {
+  tester.view.physicalSize = surface;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+        tripReviewApiServiceProvider
+            .overrideWithValue(_FakeReviewApiService(review)),
+      ],
+      child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: TripDetailScreen(tripId: 't1')),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+ScrollPosition _position(WidgetTester tester) => tester
+    .state<ScrollableState>(find
+        .descendant(
+            of: find.byType(CustomScrollView),
+            matching: find.byType(Scrollable))
+        .first)
+    .position;
+
+void main() {
+  testWidgets(
+      'wide: map left beside the stacked Next Step + Continue chat cards; '
+      'scrolling moves the row off while the tab row stays pinned',
+      (tester) async {
+    await _pump(
+      tester,
+      trip: _trip(
+          chat: const TripRefineChat(
+        messageCount: 17,
+        preview: 'Great choice! Go ahead and add it.',
+        updatedAt: '2026-08-25T10:00:00Z',
+      )),
+      review: _lodgingReview,
+      surface: const Size(1200, 800),
+    );
+
+    final mapRect = tester.getRect(find.byType(TripMap));
+    final nextRect =
+        tester.getRect(find.byKey(const ValueKey('next-step-card')));
+    final chatRect =
+        tester.getRect(find.byKey(const ValueKey('continue-chat-row')));
+
+    // Side by side, map LEFT: both cards start right of the map's right
+    // edge, and the map is the wider column (flex 6:5).
+    expect(mapRect.right, lessThanOrEqualTo(nextRect.left),
+        reason: 'the map column must sit left of the Next Step card');
+    expect(mapRect.right, lessThanOrEqualTo(chatRect.left),
+        reason: 'the map column must sit left of the Continue-chat card');
+    expect(mapRect.width, greaterThan(nextRect.width),
+        reason: 'the map takes the larger share of the row (~55%)');
+    // The two cards stack in one column, top edges tied to the map row.
+    expect(nextRect.bottom, lessThanOrEqualTo(chatRect.top),
+        reason: 'Next Step stacks above Continue chat');
+    expect((nextRect.top - mapRect.top).abs(), lessThanOrEqualTo(1),
+        reason: 'the column tops align with the map');
+    expect((chatRect.bottom - mapRect.bottom).abs(), lessThanOrEqualTo(1),
+        reason: 'the column stretches to the map\'s bottom edge');
+
+    // The stacked card keeps its full wiring at column width — the action
+    // buttons are present (wrapped below the text, but presence is the
+    // structural fact worth pinning here).
+    expect(
+        find.descendant(
+            of: find.byKey(const ValueKey('next-step-card')),
+            matching: find.byKey(const ValueKey('next-step-primary'))),
+        findsOneWidget);
+
+    // Scrolling: the whole row leaves; the tab row keeps pinning alone.
+    final position = _position(tester);
+    expect(position.maxScrollExtent, greaterThan(0),
+        reason: 'premise: the fixture must scroll');
+    position.jumpTo(position.maxScrollExtent);
+    await tester.pumpAndSettle();
+    final mapGone = find.byType(TripMap);
+    if (mapGone.evaluate().isNotEmpty) {
+      expect(tester.getRect(mapGone).bottom, lessThanOrEqualTo(0),
+          reason: 'the map row must scroll fully off (it used to pin)');
+    }
+    expect(find.text('Itinerary'), findsOneWidget,
+        reason: 'the tab row is the one piece of chrome that still pins');
+  });
+
+  testWidgets(
+      'wide with no next step and no conversation: the map spans the full '
+      'content width — and still scrolls away', (tester) async {
+    // No refineChat; the review resolves with NO next step, so the right
+    // column has nothing to hold and must not reserve its 45%.
+    await _pump(
+      tester,
+      trip: _trip(),
+      review: const TripReview(findings: []),
+      surface: const Size(1200, 800),
+    );
+
+    expect(find.byKey(const ValueKey('next-step-card')), findsNothing);
+    expect(find.byKey(const ValueKey('continue-chat-row')), findsNothing);
+
+    // Full content width: the 1200px body caps content at 900 (gutters
+    // 150 each side), so the map card's box spans ~900 — not the ~55%
+    // (~490px) row share.
+    final mapWidth = tester.getRect(find.byType(TripMap)).width;
+    expect(mapWidth, greaterThan(850),
+        reason: 'with both cards absent the map takes the whole row');
+
+    // And it is page flow, not chrome: scrolling carries it off.
+    final position = _position(tester);
+    expect(position.maxScrollExtent, greaterThan(0),
+        reason: 'premise: the fixture must scroll');
+    position.jumpTo(position.maxScrollExtent);
+    await tester.pumpAndSettle();
+    final mapGone = find.byType(TripMap);
+    if (mapGone.evaluate().isNotEmpty) {
+      expect(tester.getRect(mapGone).bottom, lessThanOrEqualTo(0),
+          reason: 'the full-width map must scroll away too');
+    }
+  });
+
+  testWidgets(
+      'narrow guard rail: the scroll-away tap-to-expand preview is unchanged',
+      (tester) async {
+    // This pin PASSES against the pre-redesign code too — it is the guard
+    // that the phone layout stayed byte-for-byte, not a fail-against-old
+    // probe like the two above.
+    await _pump(
+      tester,
+      trip: _trip(
+          chat: const TripRefineChat(
+        messageCount: 3,
+        preview: 'Naxos then Paros.',
+        updatedAt: '2026-08-25T10:00:00Z',
+      )),
+      review: _lodgingReview,
+      surface: const Size(375, 800),
+    );
+
+    // Cards stack full-width ABOVE the map preview (no side-by-side row).
+    final mapRect = tester.getRect(find.byType(TripMap));
+    final nextRect =
+        tester.getRect(find.byKey(const ValueKey('next-step-card')));
+    expect(nextRect.bottom, lessThanOrEqualTo(mapRect.top),
+        reason: 'phones keep the stacked header: cards above the preview');
+    expect(nextRect.width, greaterThan(300),
+        reason: 'phone cards keep the full content width');
+
+    // The preview is the pointer-absorbing tap-to-expand card: no inline
+    // zoom controls, an expand affordance, and a page scroll moves it.
+    expect(
+        find.descendant(
+            of: find.byType(TripMap), matching: find.byIcon(Icons.add)),
+        findsNothing,
+        reason: 'the phone preview absorbs pointers — no zoom controls');
+    expect(find.byIcon(Icons.fullscreen), findsOneWidget);
+    final position = _position(tester);
+    position.jumpTo(200);
+    await tester.pumpAndSettle();
+    final mapAfter = find.byType(TripMap);
+    if (mapAfter.evaluate().isNotEmpty) {
+      expect(tester.getRect(mapAfter).top, lessThan(mapRect.top),
+          reason: 'the preview scrolls with the page, as it always has');
+    }
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_scroll_perf_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_scroll_perf_test.dart
@@ -19,13 +19,16 @@ import 'support/l10n_test_app.dart';
 /// continuous scrolling got slower the longer it ran because (a) every row
 /// crossing under a parked cursor started a 120ms AnimatedOpacity fade — a
 /// rolling set of saveLayers per frame on CanvasKit — and (b) the pinned
-/// chrome (map band, tab row, city/day headers) had no RepaintBoundary, so
-/// its picture was re-recorded every scroll frame. These tests pin the two
-/// structural fixes:
+/// chrome (then map band + tab row, plus city/day headers) had no
+/// RepaintBoundary, so its picture was re-recorded every scroll frame.
+/// These tests pin the two structural fixes:
 ///   * no AnimatedOpacity anywhere on the screen — hover reveal is instant;
-///   * the map card, pinned-header chrome, and city/day headers sit behind
-///     RepaintBoundaries (the card's boundary lives INSIDE _mapCard, so both
-///     the pinned wide band and the scroll-away phone card get it).
+///   * the map card, pinned chrome, and city/day headers sit behind
+///     RepaintBoundaries. The card's boundary lives inside the band widget,
+///     so the wide map row and the scroll-away phone card both get it —
+///     since the map-row redesign the card scrolls with the page at every
+///     width, so its boundary now earns its keep on tap-time rebuilds
+///     (chip taps, camera moves) rather than on scroll frames.
 void main() {
   ItineraryItem item(int pos, String name, String city, double lat, double lng,
           int day) =>
@@ -91,7 +94,7 @@ void main() {
   }
 
   testWidgets(
-      'wide layout: map card + pinned chrome + city/day headers are '
+      'wide layout: map card + city/day headers are '
       'repaint-isolated and nothing on the screen fades', (tester) async {
     useSurface(tester, const Size(1200, 2200));
     await pump(tester, threeCityTrip());
@@ -108,7 +111,7 @@ void main() {
         ),
       ),
       findsWidgets,
-      reason: 'the pinned map card must repaint in its own layer',
+      reason: 'the map card must repaint in its own layer',
     );
 
     // City headers (expanded at boot) are individually boundaried.
@@ -163,7 +166,8 @@ void main() {
     await pump(tester, threeCityTrip());
 
     // Same assertion as the wide layout: proves the boundary lives inside
-    // _mapCard rather than only in the pinned-header delegate.
+    // the band widget itself, so both hosts (wide map row, phone preview
+    // sliver) get it without either restating it.
     expect(
       find.descendant(
         of: find.byType(CustomScrollView),


### PR DESCRIPTION
Implements the approved map-row ticket (epic artifact `trip-detail-map-row`, approved 2026-08-26 "build it as specced"). Wide trip detail only; the phone layout is untouched.

## What changed

- **Side-by-side map row** (`TripDetailMapRow`, map_band.dart): inside the 900px cap the map card sits left at flex 6:5 (~55%), min-height 300 (≈1.55:1 at the cap — the wireframe's ≈1.6:1), with the Next Step and Continue-chat cards stacked in the right column, stretched to the map's height via IntrinsicHeight (a tall Spanish card grows the row rather than overflowing). One card absent → the other fills the column; both absent → the map spans the full content width. `TripHeaderCard` hosts the row (it owns the two cards' presence logic and session state); the screen passes the pre-built map card in as a slot.
- **The band no longer pins; the tab row pins alone.** The pinned `SliverPersistentHeader` branch and `mapBandHeaderHeight` are gone; `_pinnedChrome` collapses to the 56px tab row at every width. ~360px of permanent chrome returns to the itinerary.
- **The wide inline map stays fully interactive** (pan/zoom/chips/expand) — it is not the phone's AbsorbPointer preview; it just scrolls with the page now.
- **`NextStepCard.stacked`**: at column width the trailing buttons wrap below the text (Wrap, so long Spanish label pairs drop a line instead of clipping); outer top margin is owned by the column.

## `_mapPinned` — per-site decisions (each an intent question)

| Site (pre-change) | Decision |
|---|---|
| `:3731` assignment | Flag deleted; `!_narrow` (root LayoutBuilder) is the one layout switch — the two widths always agreed (Scaffold adds no horizontal chrome), noted at the field. |
| `:818` chrome extent | Band term deleted; `_pinnedChrome` is now a const = tab row. All three consumers (day/city correction passes, fold anchor) follow. |
| `:1076` chip-tap reveal | Wide adopts the unpinned semantics: **no auto-reveal at any width** — the chips ride a card that scrolls with the page, so scrolling would hide the map being focused. The accepted-tradeoff row in the ticket, not a regression. Group un-collapse on chip tap is kept. |
| `:3485` full-screen report-back | Pre-scroll now fires at **every** width: with the band scrolled away, the modal's chip taps need it exactly as phones do. |

No additional flag sites existed beyond comments (updated).

## New-world consequence surfaced by tests

With the band in page flow, the inline map **unmounts** once scrolled past the cache extent — the old pinned band was always alive. Tests that read inline map state after a scroll now jump back to the top first (the phone tests' own pattern; focus lives in notifiers and survives the unmount). The `all_expanded_headers` far-upward estimation probe captures the region-pin callback while the map is mounted — the scroll math it guards is offset-independent.

## Tests

- Full suite: **2020 passed, 0 failed**, `EXIT=0` captured directly (no pipe).
- `flutter analyze --no-fatal-infos --fatal-warnings`: 0 errors/warnings (3 pre-existing route_response.dart infos).
- New pins (`trip_detail_map_row_test.dart`), fail-against-old verified by stashing lib:
  - (a) side-by-side + band scrolls off while tab row pins — red on old: `map right 1050 !≤ card left 150` ("the map column must sit left of the Next Step card").
  - (b) both cards absent → full-width map that scrolls away — red on old: `map bottom 344 !≤ 0` ("the full-width map must scroll away too") — 344 = the old pinned chrome, exactly.
  - (c) narrow guard rail — **passes against old too, deliberately** (it pins that phones didn't change, not the redesign).
- Updated for the redesign: `leg_focus` (chip-tap rest test → chip-tap-never-scrolls + collapsed-group re-open; slot math drops the band term), `all_expanded_headers` (slot math, captured callback), `map_expand` (wide pinned test → interactive-and-scrolls-away; new wide pre-scroll pin), `scroll_perf` (comments only — the RepaintBoundary survives for tap-time isolation).

## Brand check

`check.sh` reports one finding in trip_detail_screen.dart:4576 (`Radius.circular(16)` in the refine sheet) — pre-existing and untouched by this diff (whole-file lint; zero `Radius.circular` lines in the change).

## Not browser-verified (flagged)

The local API binary on :8080 predates the trip-create endpoint (405), and standing up a fresh stack or driving agent/import endpoints would spend tokens or touch live dev data — the row's geometry (flex split, 300 floor, stretch behavior) is pinned by font-independent widget geometry instead. Worth a dogfood look after merge; if the camera framing wants adjusting at 55% width, the fix is fit padding at the call site per the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790339642&installation_model_id=433099&pr_number=575&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F575&signature=9573c74d4a2df2714e55df29a1696e8a55cb3a9b23e671b1cf89a9f5fe07d5d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->