### PR TITLE
feat(trip-detail): mid-trip, departed cities fold to their headers

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -271,7 +271,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   // Today mode (specs/today-mode): the itinerary auto-scrolls to today's day
   // header at most once per screen visit, and only from loud load paths.
   final ScrollController _scroll = ScrollController();
-  bool _autoScrolledToday = false;
+  bool _todayModeEntered = false;
   // Day set by a loud load, consumed by the first build that has the scroll
   // view on screen (the load's own setState still shows the loading spinner,
   // so the scroll can't be kicked off from there).
@@ -635,9 +635,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
             _loading = false;
             // Today mode treats this as the trip's first paint (the
             // cached-offline fallback's precedent); the fresh landing
-            // below then no-ops via _autoScrolledToday, so the swap can
+            // below then no-ops via _todayModeEntered, so the swap can
             // never re-scroll out from under the traveler.
-            if (!silent) _maybeAutoScrollToday(cached.trip);
+            if (!silent) _maybeEnterTodayMode(cached.trip);
           });
         }
       }
@@ -677,7 +677,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           _loading = false;
           // Today mode fires only from loud loads — never from a silent
           // refresh, which shares this success path (PR #51/#53 invariants).
-          if (!silent) _maybeAutoScrollToday(trip);
+          if (!silent) _maybeEnterTodayMode(trip);
         });
         // Remember this as the most recently viewed trip (home screen tile).
         ref.read(recentTripProvider.notifier).record(
@@ -763,7 +763,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
             _error = null;
             // Opening a live trip while offline is Today mode's prime use
             // case — the cached copy scrolls to today just like a live load.
-            if (!silent) _maybeAutoScrollToday(cached.trip);
+            if (!silent) _maybeEnterTodayMode(cached.trip);
           });
           return; // finally still clears _loading
         }
@@ -925,28 +925,51 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     return box is RenderBox && box.hasSize ? box.size.height : 0;
   }
 
-  /// One-shot Today trigger, called inside the setState of the loud load
+  /// One-shot Today-mode entry, called inside the setState of the loud load
   /// paths (live success, cache-first paint, and cached-offline fallback) so
-  /// the map's today focus preselection lands in the same frame as the trip.
-  /// Never called from silent refreshes; a no-op once fired, while the refine
-  /// panel is open, or when the trip is undated/past/future or has no day
-  /// tags.
-  void _maybeAutoScrollToday(Trip trip) {
-    if (_autoScrolledToday || _panelOpen) return;
-    final today = tripDayOn(trip.startDate, trip.endDate, DateTime.now());
+  /// the map's today focus preselection and the past-leg fold land in the
+  /// same frame as the trip. Never called from silent refreshes; a no-op once
+  /// fired, while the refine panel is open, or when the trip is
+  /// undated/past/future or has no day tags. Three effects, one gate: the
+  /// map preselects today's leg, cities already departed land collapsed, and
+  /// the list scrolls to today's header.
+  void _maybeEnterTodayMode(Trip trip) {
+    if (_todayModeEntered || _panelOpen) return;
+    final now = DateTime.now();
+    final today = tripDayOn(trip.startDate, trip.endDate, now);
     if (today == null) return;
     if (!(trip.items ?? const <ItineraryItem>[]).any((i) => i.day != null)) {
       return;
     }
-    _autoScrolledToday = true;
+    _todayModeEntered = true;
     // Map preselect: the leg holding today's items, set before the first
     // paint so the camera doesn't hop All → today one frame later.
     // Exact-day match only — an untagged today leaves the default (All)
     // and the pending scroll's nearest-day fallback selects. Map-only:
-    // groups land expanded by default, so there is nothing to open.
+    // today's own group never collapses (exempt below), so the focus
+    // target is always open.
     final d = _derive(trip);
     final todayLeg = d.legKeyForDay(today);
     if (todayLeg != null) _setMapFocus(d, todayLeg);
+    // Cities already departed land collapsed: mid-trip, the history above
+    // today folds to its headers so the screen opens at the trip's live
+    // edge, not at day 1. Seeded ONCE into _collapsedGroups — the same
+    // inverted session set a header tap edits — so re-expanding a past city
+    // sticks for the visit and silent refreshes never re-fold it. The
+    // decision reads visibleRanges (index-aligned with legs), because that
+    // is the span the header chip promises the user; the compare is
+    // strictly-before on UTC-normalized civil dates (the daysUntilTrip
+    // rule), so the city being departed TODAY keeps its morning visible.
+    // Today's leg is exempt outright as belt-and-braces against a range
+    // that disagrees with the day tags.
+    final todayUtc = DateTime.utc(now.year, now.month, now.day);
+    for (var i = 0; i < d.legs.length && i < d.visibleRanges.length; i++) {
+      final end = d.visibleRanges[i].end;
+      if (end == null || d.legs[i].key == todayLeg) continue;
+      if (DateTime.utc(end.year, end.month, end.day).isBefore(todayUtc)) {
+        _collapsedGroups.add(d.legs[i].key);
+      }
+    }
     // The scroll itself waits for the first build that actually shows the
     // scroll view: a post-frame callback scheduled here could fire before
     // the CustomScrollView has laid out (and on paths where this setState

--- a/src/packages/flutter-app/test/trip_detail_past_cities_collapse_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_past_cities_collapse_test.dart
@@ -1,0 +1,228 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/models/booking_todo.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/route_request.dart';
+import 'package:travel_route_planner/models/route_response.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/weather.dart';
+import 'package:travel_route_planner/providers/api_client_provider.dart';
+import 'package:travel_route_planner/providers/booking_todos_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/providers/weather_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/booking_todos_api_service.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/services/weather_api_service.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Past cities land collapsed (specs/today-mode): opening an IN-PROGRESS trip
+/// folds the city groups whose visible range ended before today, so the
+/// screen opens at the trip's live edge instead of days of history. The fold
+/// is a one-shot seed into the same session set a header tap edits — the
+/// traveler re-expanding a past city wins — and trips that are undated, not
+/// started, or already finished render exactly as before.
+///
+/// All assertions are structural (widget presence/absence, taps); nothing
+/// measures rendered text (the widget-test font is not Inter; see CLAUDE.md).
+/// Dates are built relative to the device's civil date, UTC-normalized like
+/// utils/trip_days.dart's daysUntilTrip, so a DST transition inside the
+/// fixture window cannot shift a day.
+
+final DateTime _now = DateTime.now();
+final DateTime _todayUtc = DateTime.utc(_now.year, _now.month, _now.day);
+
+String _iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+/// The civil date [days] from today, as the API's YYYY-MM-DD.
+String _rel(int days) => _iso(_todayUtc.add(Duration(days: days)));
+
+class _OneTripApiService extends TripsApiService {
+  final Trip trip;
+  _OneTripApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) => Future.value(trip);
+}
+
+class _InstantApiClient extends ApiClient {
+  _InstantApiClient() : super(baseUrl: 'http://test');
+
+  @override
+  Future<RouteResponse> optimizeRoute(RouteRequest request) =>
+      Future.value(RouteResponse(
+        optimizedRoute: const [],
+        totalDistanceKm: 0,
+        totalTravelTimeMin: 0,
+        totalVisitTimeMin: 0,
+        totalTripTimeMin: 0,
+        locationTimings: const [],
+        algorithm: 'preserve_order',
+        locationCount: 0,
+        status: 'success',
+      ));
+}
+
+class _InstantBookingTodosApiService extends BookingTodosApiService {
+  _InstantBookingTodosApiService() : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<BookingTodo>> syncTodos(
+          String tripId, List<Map<String, dynamic>> derived) =>
+      Future.value(const <BookingTodo>[]);
+}
+
+class _InstantWeatherApiService extends WeatherApiService {
+  _InstantWeatherApiService() : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<WeatherReport> getTripWeather(String city, String startDate,
+          {String? endDate}) async =>
+      const WeatherReport();
+}
+
+ItineraryItem _item(int pos, String name, {int? day, String? city}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: '$name street',
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+      day: day,
+      city: city,
+    );
+
+Trip _tripWith(String start, String end, List<ItineraryItem> items) => Trip(
+      id: 't1',
+      title: 'Long Trek',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      startDate: start,
+      endDate: end,
+      items: items,
+    );
+
+/// Day 4 of 6 today: Pastville departed the day before yesterday (its visible
+/// range ends at Currenton's arrival, yesterday+1 back — strictly past),
+/// Currenton holds today, Futureton is ahead.
+Trip _midTrip() => _tripWith(_rel(-3), _rel(2), [
+      _item(0, 'Old Fort', day: 1, city: 'Pastville'),
+      _item(1, 'Old Cafe', day: 2, city: 'Pastville'),
+      _item(2, 'Now Plaza', day: 3, city: 'Currenton'),
+      _item(3, 'Now Museum', day: 4, city: 'Currenton'),
+      _item(4, 'Next Pier', day: 5, city: 'Futureton'),
+      _item(5, 'Next Park', day: 6, city: 'Futureton'),
+    ]);
+
+/// The city being departed TODAY: Leaveton's visible range ends at
+/// Nextville's arrival — today, not strictly before it.
+Trip _departingTodayTrip() => _tripWith(_rel(-1), _rel(1), [
+      _item(0, 'Morning Walk', day: 1, city: 'Leaveton'),
+      _item(1, 'Arrival Fair', day: 2, city: 'Nextville'),
+    ]);
+
+Future<void> _pump(WidgetTester tester, Trip trip) async {
+  // Tall surface so every fixture lays out in full: slivers are lazy, and on
+  // the default 600px window a below-fold item is simply never built — which
+  // would make the collapsed-vs-rendered assertions here indistinguishable
+  // from scroll position. At 2600px the whole list fits, the Today
+  // auto-scroll has nothing to scroll, and absence means COLLAPSED.
+  tester.view.physicalSize = const Size(1200, 2600);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_OneTripApiService(trip)),
+        apiClientProvider.overrideWithValue(_InstantApiClient()),
+        bookingTodosApiServiceProvider
+            .overrideWithValue(_InstantBookingTodosApiService()),
+        weatherApiServiceProvider
+            .overrideWithValue(_InstantWeatherApiService()),
+      ],
+      child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: TripDetailScreen(tripId: 't1')),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('mid-trip: departed city lands collapsed, today and the future stay open',
+      (WidgetTester tester) async {
+    await _pump(tester, _midTrip());
+
+    // Pastville folded to its header: the header renders, its items do not.
+    expect(find.text('Pastville'), findsWidgets);
+    expect(find.text('Old Fort'), findsNothing);
+    expect(find.text('Old Cafe'), findsNothing);
+
+    // Today's city and the one ahead render in full.
+    expect(find.text('Now Plaza'), findsWidgets);
+    expect(find.text('Now Museum'), findsWidgets);
+    expect(find.text('Next Pier'), findsWidgets);
+    expect(find.text('Next Park'), findsWidgets);
+  });
+
+  testWidgets('a header tap re-expands a folded past city, and it stays open',
+      (WidgetTester tester) async {
+    await _pump(tester, _midTrip());
+    expect(find.text('Old Fort'), findsNothing);
+
+    // The whole city header is the InkWell toggle.
+    await tester.tap(find.text('Pastville').first);
+    await tester.pumpAndSettle();
+    expect(find.text('Old Fort'), findsWidgets);
+
+    // The seed is one-shot: later frames must not re-fold the traveler's
+    // choice (regression guard against seeding from build).
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
+    expect(find.text('Old Fort'), findsWidgets);
+  });
+
+  testWidgets('the city being departed today keeps its morning visible',
+      (WidgetTester tester) async {
+    await _pump(tester, _departingTodayTrip());
+    expect(find.text('Morning Walk'), findsWidgets);
+    expect(find.text('Arrival Fair'), findsWidgets);
+  });
+
+  testWidgets('a trip that has not started folds nothing',
+      (WidgetTester tester) async {
+    await _pump(
+        tester,
+        _tripWith(_rel(1), _rel(3), [
+          _item(0, 'First Stop', day: 1, city: 'Alpha'),
+          _item(1, 'Second Stop', day: 3, city: 'Beta'),
+        ]));
+    expect(find.text('First Stop'), findsWidgets);
+    expect(find.text('Second Stop'), findsWidgets);
+  });
+
+  testWidgets('a finished trip folds nothing — a memento renders in full',
+      (WidgetTester tester) async {
+    await _pump(
+        tester,
+        _tripWith(_rel(-5), _rel(-3), [
+          _item(0, 'Was First', day: 1, city: 'Alpha'),
+          _item(1, 'Was Last', day: 3, city: 'Beta'),
+        ]));
+    expect(find.text('Was First'), findsWidgets);
+    expect(find.text('Was Last'), findsWidgets);
+  });
+}


### PR DESCRIPTION
## Summary
- Opening an **in-progress** trip now collapses the city accordions whose dates have fully passed, so the page opens at the trip's live edge instead of days of history. A header tap re-expands any of them, and that choice sticks for the visit — nothing ever re-folds it.
- The fold rides the existing Today-mode one-shot (renamed `_maybeAutoScrollToday` → `_maybeEnterTodayMode`), inheriting its settled gates: loud loads only, never silent refreshes, once per visit, in-progress trips with day tags. Not-started trips, finished trips (a memento renders in full), and legacy dayless trips render exactly as before.
- "Past" is decided against `visibleRanges` — the same spans the header chips display — strictly-before today on UTC-normalized civil dates (the `daysUntilTrip` DST rule). Strictly-before keeps the city being departed **today** open through its last morning; today's leg is exempt outright, which also keeps the map's today-focus target always open. Revisits work by construction (`#2`-suffixed run keys): a past first visit folds, the upcoming return stays open.
- Decision record in the epic artifact `past-cities-collapse`.

## Testing
- Full suite: **2025 passed, 0 failed** (2020 existing + 5 new).
- 5 structural widget tests: the mid-trip fold with today and future cities open, tap-to-re-expand sticking across later frames, the departing-today edge, and both no-op cases. Fixture dates now-relative and UTC-normalized; nothing font-dependent.
- Test-craft note for the reviewer: the fixtures pump on a 2600px surface deliberately — slivers are lazy, so on the default window "absent" can mean not-laid-out rather than collapsed; the tall surface is what makes the negative assertions sound (my first draft's were vacuous and failed honest).
- `flutter analyze`: only the 3 pre-existing infos. Brand check: only the pre-existing radius literal at `trip_detail_screen.dart:4599`, outside this diff.

## Not verified
- The taste call: whether landing on a shorter page that opens at today feels right. The natural first look is a live in-progress trip (it should open with past cities folded and today's city front and center).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790371904&installation_model_id=433099&pr_number=576&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F576&signature=dc0ca6f8ee6539e7a20c3af0da9ad9530f9a18107c7106255243653e393213be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->