### PR TITLE
fix(api): /optimize-route per-location resolution, honest status codes, mode-aware travel times

### DIFF
--- a/src/packages/api/itinerary_optimizer.go
+++ b/src/packages/api/itinerary_optimizer.go
@@ -81,8 +81,13 @@ func optimizeBlockOrder(locations []map[string]any, idxs []int) []map[string]any
 
 	// Reuse the location-route optimizer's lower-level steps directly; we only
 	// need the reordered sequence, not its timing/Places-resolution machinery.
+	// Every loc has coordinates (guarded above), so all indices are candidates.
 	ro := NewRouteOptimizer(locs)
-	route := ro.optimizeWith2Opt(ro.nearestNeighborRoute(0, false), false, 100)
+	all := make([]int, len(locs))
+	for i := range all {
+		all[i] = i
+	}
+	route := ro.optimizeWith2Opt(ro.nearestNeighborRoute(0, all), false, 100)
 
 	out := make([]map[string]any, 0, len(idxs))
 	for _, local := range route {

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -198,7 +198,32 @@ func optimizeRouteHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Create optimizer and process request
 	optimizer := NewRouteOptimizer(request.Locations)
-	result := optimizer.OptimizeRoute(r.Context(), request)
+	result, err := optimizer.OptimizeRoute(r.Context(), request)
+	if err != nil {
+		// An error is the whole-request failure lane and is never a 200: a
+		// 200 always carries non-null optimized_route and location_timings
+		// (partial resolution stays a 200, reporting skips in `unresolved`).
+		var allUnresolved *allUnresolvedError
+		status := http.StatusBadRequest
+		message := err.Error()
+		if errors.As(err, &allUnresolved) {
+			// Every location failed resolution. Blame the request (422) only
+			// when at least one failure was request-side; a pure provider
+			// outage (Places down, quota, missing key) is a 503.
+			status = http.StatusUnprocessableEntity
+			if allUnresolved.ProviderDown {
+				status = http.StatusServiceUnavailable
+			}
+			message = "Could not resolve any location: " + strings.Join(allUnresolved.Names, ", ")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		json.NewEncoder(w).Encode(Response{
+			Message: message,
+			Status:  "error",
+		})
+		return
+	}
 
 	// Return result
 	w.Header().Set("Content-Type", "application/json")

--- a/src/packages/api/route_contract_test.go
+++ b/src/packages/api/route_contract_test.go
@@ -1,0 +1,336 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// These tests pin the /optimize-route wire contract (specs artifact
+// day-travel-times, ticket A) at the handler level, decoding into generic maps
+// rather than the Go response structs: the pins are about the bytes a client
+// receives, and the generic decode also lets every test compile — and fail for
+// behavioral reasons, not compile errors — against the pre-fix code.
+
+// postOptimizeRoute runs one request through optimizeRouteHandler and decodes
+// the JSON body generically.
+func postOptimizeRoute(t *testing.T, request RouteRequest) (int, map[string]any) {
+	t.Helper()
+	body, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/optimize-route", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	optimizeRouteHandler(rec, req)
+
+	var decoded map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("response is not JSON (HTTP %d): %v\n%s", rec.Code, err, rec.Body.String())
+	}
+	return rec.Code, decoded
+}
+
+// timingsOf pulls location_timings as a generic slice, failing loudly when the
+// field is missing or null — the exact contract lie (200 + null) being pinned.
+func timingsOf(t *testing.T, resp map[string]any) []any {
+	t.Helper()
+	raw, present := resp["location_timings"]
+	if !present || raw == nil {
+		t.Fatalf("location_timings is %v (present=%v) — a 200 must never carry a null timings array; body: %v",
+			raw, present, resp)
+	}
+	timings, ok := raw.([]any)
+	if !ok {
+		t.Fatalf("location_timings is %T, want array", raw)
+	}
+	return timings
+}
+
+func timingEntry(t *testing.T, timings []any, i int) map[string]any {
+	t.Helper()
+	entry, ok := timings[i].(map[string]any)
+	if !ok {
+		t.Fatalf("location_timings[%d] is %T, want object", i, timings[i])
+	}
+	return entry
+}
+
+// timingNum reads a numeric field from a timing entry (JSON numbers decode as
+// float64), treating an absent field as 0 the way the Dart parser does.
+func timingNum(t *testing.T, entry map[string]any, key string) float64 {
+	t.Helper()
+	raw, present := entry[key]
+	if !present {
+		return 0
+	}
+	n, ok := raw.(float64)
+	if !ok {
+		t.Fatalf("%s is %T, want number", key, raw)
+	}
+	return n
+}
+
+// swapPlacesForRoute points the shared Places singleton at a canned Google
+// response for the duration of one test (the same pattern as
+// swapLodgingStub; placesDouble builds the service + counting transport).
+func swapPlacesForRoute(t *testing.T, body string) *countingTransport {
+	t.Helper()
+	svc, rt := placesDouble(t, body)
+	prev := placesService
+	placesService = svc
+	t.Cleanup(func() { placesService = prev })
+	return rt
+}
+
+const placesZeroResultsJSON = `{"status":"ZERO_RESULTS","results":[]}`
+const placesRequestDeniedJSON = `{"status":"REQUEST_DENIED","error_message":"key rejected"}`
+
+// amsCoord builds a coordinate-carrying location (never billed to Places).
+func amsCoord(id string, lat, lng float64) Location {
+	return Location{ID: id, Name: id, Latitude: f64(lat), Longitude: f64(lng)}
+}
+
+// TestOptimizeRoutePartialResolutionKeepsOtherTimings is the Mode B pin: one
+// unresolvable place must cost exactly its own legs, never the whole response.
+// Pre-fix, this request came back 200 with status "error resolving location
+// 'Grandmas apartment buzzer 3B'..." and location_timings null.
+func TestOptimizeRoutePartialResolutionKeepsOtherTimings(t *testing.T) {
+	rt := swapPlacesForRoute(t, placesZeroResultsJSON)
+
+	code, resp := postOptimizeRoute(t, RouteRequest{
+		PreserveOrder: true,
+		Locations: []Location{
+			amsCoord("a", 52.3579, 4.8686),
+			amsCoord("b", 52.3739, 4.8875),
+			{ID: "x", Name: "Grandmas apartment buzzer 3B"}, // name-only, unresolvable
+			amsCoord("c", 52.3660, 4.8930),
+		},
+	})
+
+	if code != http.StatusOK {
+		t.Fatalf("HTTP %d, want 200 (partial resolution is a success); body: %v", code, resp)
+	}
+	if got := resp["status"]; got != "success" {
+		t.Errorf("status = %v, want success", got)
+	}
+
+	timings := timingsOf(t, resp)
+	if len(timings) != 4 {
+		t.Fatalf("got %d timings, want 4 — preserve_order keeps one entry per input location, positionally aligned", len(timings))
+	}
+
+	// The a→b leg is between two resolved stops: it must carry real travel.
+	first := timingEntry(t, timings, 0)
+	if min := timingNum(t, first, "travel_to_next_minutes"); min <= 0 {
+		t.Errorf("timings[0].travel_to_next_minutes = %v, want > 0 — the resolvable legs must survive the bad location", min)
+	}
+	if mode, ok := first["travel_to_next_mode"].(string); !ok || (mode != "walk" && mode != "transit") {
+		t.Errorf("timings[0].travel_to_next_mode = %v, want walk|transit", first["travel_to_next_mode"])
+	}
+
+	// Legs touching the unresolved location are absent, never guessed: zero
+	// minutes/km and no mode field at all.
+	for _, i := range []int{1, 2} {
+		entry := timingEntry(t, timings, i)
+		if min := timingNum(t, entry, "travel_to_next_minutes"); min != 0 {
+			t.Errorf("timings[%d].travel_to_next_minutes = %v, want 0 (leg touches the unresolved stop)", i, min)
+		}
+		if _, has := entry["travel_to_next_mode"]; has {
+			t.Errorf("timings[%d] carries travel_to_next_mode %v — an uncomputed leg must not claim a mode", i, entry["travel_to_next_mode"])
+		}
+	}
+
+	// The skip is reported by name.
+	unresolved, ok := resp["unresolved"].([]any)
+	if !ok || len(unresolved) != 1 || unresolved[0] != "Grandmas apartment buzzer 3B" {
+		t.Errorf("unresolved = %v, want [Grandmas apartment buzzer 3B]", resp["unresolved"])
+	}
+
+	// preserve_order keeps every input location in the route, in order.
+	route, ok := resp["optimized_route"].([]any)
+	if !ok || len(route) != 4 {
+		t.Fatalf("optimized_route = %v, want 4 entries", resp["optimized_route"])
+	}
+	for i, wantID := range []string{"a", "b", "x", "c"} {
+		entry := route[i].(map[string]any)
+		if entry["id"] != wantID {
+			t.Errorf("optimized_route[%d].id = %v, want %s", i, entry["id"], wantID)
+		}
+	}
+
+	// Coordinate-carrying locations never bill Google: exactly one lookup (x).
+	if rt.calls != 1 {
+		t.Errorf("Places called %d times, want 1 (only the name-only location resolves)", rt.calls)
+	}
+}
+
+// TestOptimizeRouteAllUnresolvedIsNot200 pins the residual whole-request
+// failure as an honest non-200. Pre-fix it was a 200 whose status field
+// carried an error string and whose arrays were null.
+func TestOptimizeRouteAllUnresolvedIsNot200(t *testing.T) {
+	request := RouteRequest{
+		PreserveOrder: true,
+		Locations: []Location{
+			{ID: "x1", Name: "Nonexistent Place One"},
+			{ID: "x2", Name: "Nonexistent Place Two"},
+		},
+	}
+
+	t.Run("places_finds_nothing_is_422", func(t *testing.T) {
+		swapPlacesForRoute(t, placesZeroResultsJSON)
+		code, resp := postOptimizeRoute(t, request)
+		if code != http.StatusUnprocessableEntity {
+			t.Fatalf("HTTP %d, want 422; body: %v", code, resp)
+		}
+		if resp["status"] != "error" {
+			t.Errorf("status = %v, want error", resp["status"])
+		}
+		msg, _ := resp["message"].(string)
+		if !strings.Contains(msg, "Nonexistent Place One") || !strings.Contains(msg, "Nonexistent Place Two") {
+			t.Errorf("message %q does not name the unresolved locations", msg)
+		}
+	})
+
+	t.Run("provider_outage_is_503", func(t *testing.T) {
+		swapPlacesForRoute(t, placesRequestDeniedJSON)
+		code, resp := postOptimizeRoute(t, request)
+		if code != http.StatusServiceUnavailable {
+			t.Fatalf("HTTP %d, want 503; body: %v", code, resp)
+		}
+		if resp["status"] != "error" {
+			t.Errorf("status = %v, want error", resp["status"])
+		}
+	})
+}
+
+// TestOptimizeRouteTravelHeuristic pins the settled heuristic: detour factor
+// 1.3 on haversine, walk at/below 1.5 corrected km at 5 km/h, transit above at
+// 15 km/h, integer ceil minutes, icon mode carried per leg. Four stops on one
+// meridian give exact straight-line distances (R·Δφ):
+//
+//	p0→p1 2.4 km → 3.12 corrected → transit → 12.48 → 13 min
+//	p1→p2 1.0 km → 1.30 corrected → walk    → 15.60 → 16 min
+//	p2→p3 1.2 km → 1.56 corrected → transit →  6.24 →  7 min  (threshold reads CORRECTED km)
+//
+// Pre-fix p0→p1 was "4 min" by car — the spec's Vondelpark→'t Smalle bug.
+func TestOptimizeRouteTravelHeuristic(t *testing.T) {
+	const kmPerDegLat = 111.19492664 // 2πR/360, R=6371
+	lat0 := 52.0
+	lat1 := lat0 + 2.4/kmPerDegLat
+	lat2 := lat1 + 1.0/kmPerDegLat
+	lat3 := lat2 + 1.2/kmPerDegLat
+
+	code, resp := postOptimizeRoute(t, RouteRequest{
+		PreserveOrder: true,
+		Locations: []Location{
+			amsCoord("p0", lat0, 4.9),
+			amsCoord("p1", lat1, 4.9),
+			amsCoord("p2", lat2, 4.9),
+			amsCoord("p3", lat3, 4.9),
+		},
+	})
+	if code != http.StatusOK {
+		t.Fatalf("HTTP %d, want 200; body: %v", code, resp)
+	}
+
+	timings := timingsOf(t, resp)
+	if len(timings) != 4 {
+		t.Fatalf("got %d timings, want 4", len(timings))
+	}
+
+	wantLegs := []struct {
+		minutes float64
+		km      float64
+		mode    string
+	}{
+		{13, 3.12, "transit"},
+		{16, 1.30, "walk"},
+		{7, 1.56, "transit"},
+	}
+	for i, want := range wantLegs {
+		entry := timingEntry(t, timings, i)
+		if got := timingNum(t, entry, "travel_to_next_minutes"); got != want.minutes {
+			t.Errorf("leg %d minutes = %v, want %v", i, got, want.minutes)
+		}
+		if got := timingNum(t, entry, "travel_to_next_km"); math.Abs(got-want.km) > 0.011 {
+			t.Errorf("leg %d km = %v, want ~%v (detour-corrected)", i, got, want.km)
+		}
+		if got, _ := entry["travel_to_next_mode"].(string); got != want.mode {
+			t.Errorf("leg %d mode = %q, want %q", i, got, want.mode)
+		}
+	}
+
+	// The last stop of a one-way route has no leg and therefore no mode.
+	last := timingEntry(t, timings, 3)
+	if _, has := last["travel_to_next_mode"]; has {
+		t.Errorf("last timing carries a mode: %v", last["travel_to_next_mode"])
+	}
+
+	// Totals are the sum of the per-leg values the client can see.
+	if got := resp["total_travel_time_minutes"].(float64); got != 13+16+7 {
+		t.Errorf("total_travel_time_minutes = %v, want %d", got, 13+16+7)
+	}
+	if got := resp["total_distance_km"].(float64); math.Abs(got-(3.12+1.30+1.56)) > 0.02 {
+		t.Errorf("total_distance_km = %v, want ~%v", got, 3.12+1.30+1.56)
+	}
+}
+
+// TestOptimizeRouteOptimizeModeExcludesUnresolved pins the non-preserve-order
+// arm: a location that failed resolution has no honest place in a COMPUTED
+// order, so it is excluded from optimized_route/location_timings and reported
+// in unresolved instead.
+func TestOptimizeRouteOptimizeModeExcludesUnresolved(t *testing.T) {
+	swapPlacesForRoute(t, placesZeroResultsJSON)
+
+	code, resp := postOptimizeRoute(t, RouteRequest{
+		Locations: []Location{
+			amsCoord("a", 52.3579, 4.8686),
+			{ID: "x", Name: "Grandmas apartment buzzer 3B"},
+			amsCoord("b", 52.3739, 4.8875),
+			amsCoord("c", 52.3660, 4.8930),
+		},
+	})
+	if code != http.StatusOK {
+		t.Fatalf("HTTP %d, want 200; body: %v", code, resp)
+	}
+
+	timings := timingsOf(t, resp)
+	if len(timings) != 3 {
+		t.Fatalf("got %d timings, want 3 (the unresolved location is excluded from a computed order)", len(timings))
+	}
+	route, _ := resp["optimized_route"].([]any)
+	if len(route) != 3 {
+		t.Fatalf("optimized_route has %d entries, want 3", len(route))
+	}
+	seen := map[any]bool{}
+	for _, raw := range route {
+		seen[raw.(map[string]any)["id"]] = true
+	}
+	if seen["x"] || !seen["a"] || !seen["b"] || !seen["c"] {
+		t.Errorf("optimized_route ids = %v, want exactly {a,b,c}", seen)
+	}
+	unresolved, ok := resp["unresolved"].([]any)
+	if !ok || len(unresolved) != 1 || unresolved[0] != "Grandmas apartment buzzer 3B" {
+		t.Errorf("unresolved = %v, want the skipped location by name", resp["unresolved"])
+	}
+
+	// Every leg between the three resolved stops carries mode + minutes; the
+	// route's final stop has neither (one-way).
+	for i := 0; i < 2; i++ {
+		entry := timingEntry(t, timings, i)
+		if min := timingNum(t, entry, "travel_to_next_minutes"); min <= 0 {
+			t.Errorf("timings[%d].travel_to_next_minutes = %v, want > 0", i, min)
+		}
+		if _, hasMode := entry["travel_to_next_mode"]; !hasMode {
+			t.Errorf("timings[%d] missing travel_to_next_mode", i)
+		}
+	}
+	if _, has := timingEntry(t, timings, 2)["travel_to_next_mode"]; has {
+		t.Errorf("final stop carries a mode")
+	}
+}

--- a/src/packages/api/route_optimizer.go
+++ b/src/packages/api/route_optimizer.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -51,6 +52,11 @@ type LocationTiming struct {
 	DepartureTime    string   `json:"departure_time,omitempty"`
 	TravelToNextMin  int      `json:"travel_to_next_minutes"`
 	TravelToNextKm   float64  `json:"travel_to_next_km"`
+	// TravelToNextMode is "walk" or "transit" and is present exactly when the
+	// leg to the next stop was computed. Absent means no computed leg: the last
+	// stop of a one-way route, or a leg touching an unresolved location. The
+	// client's icon follows this field, never a distance threshold.
+	TravelToNextMode string `json:"travel_to_next_mode,omitempty"`
 }
 
 // RouteResponse represents the optimized route result
@@ -66,6 +72,12 @@ type RouteResponse struct {
 	ImprovementPct     float64          `json:"improvement_percentage,omitempty"`
 	LocationCount      int              `json:"location_count"`
 	Status             string           `json:"status"`
+	// Unresolved names the locations skipped because coordinate resolution
+	// failed (name when present, id otherwise). Their legs carry no travel
+	// data; with PreserveOrder they keep their positional entries, without it
+	// they are excluded from OptimizedRoute/LocationTimings entirely. Omitted
+	// when every location resolved.
+	Unresolved []string `json:"unresolved,omitempty"`
 }
 
 // VisitTimeEstimator handles estimation of visit durations based on location categories
@@ -332,6 +344,42 @@ func (ro *RouteOptimizer) getDistance(i, j int) float64 {
 	return dist
 }
 
+// Travel heuristic (specs artifact day-travel-times, settled 2026-08-23).
+// Straight-line under-measures real street distance by roughly a third in a
+// gridded or canal-cut city, so every reported distance is detour-corrected;
+// the walk/transit split reads on that corrected distance.
+const (
+	travelDetourFactor = 1.3
+	travelWalkMaxKm    = 1.5 // corrected distance at/below which the hop is walked
+	travelWalkKmh      = 5.0
+	travelTransitKmh   = 15.0 // city average door-to-door, waiting included
+
+	travelModeWalk    = "walk"
+	travelModeTransit = "transit"
+)
+
+// legTravel computes the reported distance, duration and mode for the leg
+// between locations i and j (indices into ro.locations). The corrected
+// (×1.3) kilometres are the ONE distance meaning every reported km field
+// carries; minutes derive from that same distance, so the two can never
+// disagree. ok is false when either endpoint lacks coordinates — such a leg
+// is reported absent (zero fields, no mode), never guessed at.
+func (ro *RouteOptimizer) legTravel(i, j int) (km float64, minutes int, mode string, ok bool) {
+	a, b := ro.locations[i], ro.locations[j]
+	if a.Latitude == nil || a.Longitude == nil || b.Latitude == nil || b.Longitude == nil {
+		return 0, 0, "", false
+	}
+	km = ro.getDistance(i, j) * travelDetourFactor
+	mode = travelModeTransit
+	speed := travelTransitKmh
+	if km <= travelWalkMaxKm {
+		mode = travelModeWalk
+		speed = travelWalkKmh
+	}
+	minutes = int(math.Ceil(km / speed * 60))
+	return km, minutes, mode, true
+}
+
 // calculateRouteDistance calculates total distance for a given route
 func (ro *RouteOptimizer) calculateRouteDistance(route []int, returnToStart bool) float64 {
 	if len(route) < 2 {
@@ -351,26 +399,29 @@ func (ro *RouteOptimizer) calculateRouteDistance(route []int, returnToStart bool
 	return totalDistance
 }
 
-// nearestNeighborRoute creates initial route using nearest neighbor algorithm
-func (ro *RouteOptimizer) nearestNeighborRoute(startIndex int, returnToStart bool) []int {
-	n := len(ro.locations)
-	if n == 0 {
+// nearestNeighborRoute creates an initial route over the candidate indices
+// using the nearest neighbor algorithm. Only candidates participate: a
+// coordinate-less location cannot be placed by distance math (getDistance
+// reads it as 0 km from everywhere, which would distort even the resolved
+// locations' ordering). startIndex must be one of the candidates.
+func (ro *RouteOptimizer) nearestNeighborRoute(startIndex int, candidates []int) []int {
+	if len(candidates) == 0 {
 		return []int{}
 	}
 
-	route := make([]int, 0, n)
-	visited := make([]bool, n)
+	route := make([]int, 0, len(candidates))
+	visited := make(map[int]bool, len(candidates))
 
 	current := startIndex
 	route = append(route, current)
 	visited[current] = true
 
-	// Build route by always going to nearest unvisited location
-	for len(route) < n {
+	// Build route by always going to nearest unvisited candidate
+	for len(route) < len(candidates) {
 		nearest := -1
 		minDist := math.Inf(1)
 
-		for i := 0; i < n; i++ {
+		for _, i := range candidates {
 			if !visited[i] {
 				dist := ro.getDistance(current, i)
 				if dist < minDist {
@@ -452,17 +503,6 @@ func (ro *RouteOptimizer) optimizeWith2Opt(initialRoute []int, returnToStart boo
 	return currentRoute
 }
 
-// findLocationIndex finds the index of a location by ID in the locations array
-func (ro *RouteOptimizer) findLocationIndex(locationID string) int {
-	for i, location := range ro.locations {
-		if location.ID == locationID {
-			return i
-		}
-	}
-	return -1
-}
-
-// OptimizeRoute is the main function to optimize a route
 // resolveLocation resolves a location's coordinates and details from Google Places API
 func (ro *RouteOptimizer) resolveLocation(ctx context.Context, location *Location, placesService *GooglePlacesService) error {
 	// If we already have coordinates, no need to resolve
@@ -522,21 +562,68 @@ func (ro *RouteOptimizer) resolveLocation(ctx context.Context, location *Locatio
 	return nil
 }
 
-func (ro *RouteOptimizer) OptimizeRoute(ctx context.Context, request RouteRequest) RouteResponse {
+// errNoLocations is OptimizeRoute's guard against an empty request; the
+// handler pre-validates this, so it maps to the same 400.
+var errNoLocations = errors.New("at least one location is required")
+
+// allUnresolvedError is the residual whole-request failure: not one location
+// could be resolved to coordinates, so there is no route to compute. The
+// handler maps it to an honest non-200 — 422 when at least one failure blames
+// the request (a place Google can't find, a location with nothing to look
+// up), 503 when every failure was provider-side (outage, quota, missing key).
+type allUnresolvedError struct {
+	Names        []string
+	ProviderDown bool
+}
+
+func (e *allUnresolvedError) Error() string {
+	return "could not resolve any location: " + strings.Join(e.Names, ", ")
+}
+
+// resolutionIsRequestSide reports whether a resolveLocation failure blames the
+// request rather than the provider. "no places found" is resolveLocation's own
+// empty-search string; ZERO_RESULTS classification matches the trip-import
+// pipeline's isPlacesZeroResults.
+func resolutionIsRequestSide(loc Location, err error) bool {
+	if loc.PlaceID == "" && loc.Name == "" {
+		return true // nothing to look up — never the provider's fault
+	}
+	return isPlacesZeroResults(err) || strings.Contains(err.Error(), "no places found")
+}
+
+func (ro *RouteOptimizer) OptimizeRoute(ctx context.Context, request RouteRequest) (RouteResponse, error) {
 	if len(request.Locations) == 0 {
-		return RouteResponse{
-			Status: "error: no locations provided",
-		}
+		return RouteResponse{}, errNoLocations
 	}
 
 	// Resolve locations that don't have coordinates (via the shared
-	// placesService singleton so lookups hit its TTL caches)
+	// placesService singleton so lookups hit its TTL caches). A failed
+	// resolution SKIPS that location — it is reported in Unresolved and its
+	// legs stay uncomputed — so one bad place on day 9 can no longer erase
+	// day 2's timings. Only the residual nothing-resolved case is an error.
+	var unresolved []string
+	requestSideFailure := false
 	for i := range request.Locations {
-		if err := ro.resolveLocation(ctx, &request.Locations[i], placesService); err != nil {
-			return RouteResponse{
-				Status: fmt.Sprintf("error resolving location '%s': %v", request.Locations[i].Name, err),
-			}
+		err := ro.resolveLocation(ctx, &request.Locations[i], placesService)
+		if err == nil {
+			continue
 		}
+		loc := request.Locations[i]
+		name := loc.Name
+		if name == "" {
+			name = loc.ID
+		}
+		// Provider/internal error detail stays in the server log; the response
+		// carries only the caller's own location names.
+		ctxLog(ctx).Warn("optimize-route: skipping unresolvable location",
+			"location", name, "error", err)
+		unresolved = append(unresolved, name)
+		if resolutionIsRequestSide(loc, err) {
+			requestSideFailure = true
+		}
+	}
+	if len(unresolved) == len(request.Locations) {
+		return RouteResponse{}, &allUnresolvedError{Names: unresolved, ProviderDown: !requestSideFailure}
 	}
 
 	if len(request.Locations) == 1 {
@@ -577,14 +664,17 @@ func (ro *RouteOptimizer) OptimizeRoute(ctx context.Context, request RouteReques
 			LocationCount:      1,
 			Algorithm:          "single-location",
 			Status:             "success",
-		}
+		}, nil
 	}
 
-	// Set up locations and determine start index
+	// Set up locations and split off the indices that actually resolved —
+	// only those can participate in distance math.
 	ro.locations = request.Locations
-	startIndex := 0
-	if request.StartIndex != nil && *request.StartIndex >= 0 && *request.StartIndex < len(request.Locations) {
-		startIndex = *request.StartIndex
+	resolvedIdx := make([]int, 0, len(request.Locations))
+	for i, loc := range request.Locations {
+		if loc.Latitude != nil && loc.Longitude != nil {
+			resolvedIdx = append(resolvedIdx, i)
+		}
 	}
 
 	var optimizedRoute []int
@@ -592,7 +682,10 @@ func (ro *RouteOptimizer) OptimizeRoute(ctx context.Context, request RouteReques
 	algorithm := "nearest-neighbor + 2-opt"
 
 	if request.PreserveOrder {
-		// Keep the caller-supplied order; only compute per-leg timings below.
+		// Keep the caller-supplied order — including unresolved locations at
+		// their positions, because the timings array is positionally keyed to
+		// the request and dropping an entry would shift every later timing
+		// onto the wrong location. Their legs contribute nothing below.
 		optimizedRoute = make([]int, len(request.Locations))
 		for i := range optimizedRoute {
 			optimizedRoute[i] = i
@@ -601,8 +694,17 @@ func (ro *RouteOptimizer) OptimizeRoute(ctx context.Context, request RouteReques
 		originalDistance = optimizedDistance
 		algorithm = "preserve-order"
 	} else {
-		// Create initial route using nearest neighbor
-		initialRoute := ro.nearestNeighborRoute(startIndex, request.ReturnToStart)
+		// Route only over the resolved locations; an unresolvable place has
+		// no honest position in a computed order, so it is excluded from the
+		// route entirely (and named in Unresolved). Start from the requested
+		// index when it resolved, else from the first resolved location.
+		startIndex := resolvedIdx[0]
+		if request.StartIndex != nil && *request.StartIndex >= 0 && *request.StartIndex < len(request.Locations) {
+			if s := *request.StartIndex; request.Locations[s].Latitude != nil && request.Locations[s].Longitude != nil {
+				startIndex = s
+			}
+		}
+		initialRoute := ro.nearestNeighborRoute(startIndex, resolvedIdx)
 		originalDistance = ro.calculateRouteDistance(initialRoute, request.ReturnToStart)
 
 		// Optimize using 2-opt (limit iterations for performance)
@@ -650,12 +752,15 @@ func (ro *RouteOptimizer) OptimizeRoute(ctx context.Context, request RouteReques
 		}
 	}
 
-	// Calculate travel time (assuming average speed of 40 km/h in city)
-	travelTimeMin := int(math.Ceil(optimizedDistance / 40.0 * 60))
-
-	// Calculate visit times and create detailed timing information with operating hours
+	// Calculate visit times and create detailed timing information with
+	// operating hours. Totals are the SUM of the per-leg values below — the
+	// route is not traveled at one blended speed, so there is no meaningful
+	// whole-route formula anymore; what the client can sum from the entries
+	// is what the totals say.
 	locationTimings := make([]LocationTiming, len(result))
 	totalVisitTime := 0
+	totalTravelTime := 0
+	totalTravelKm := 0.0
 	currentTime := startDateTime
 
 	for i, location := range result {
@@ -673,24 +778,25 @@ func (ro *RouteOptimizer) OptimizeRoute(ctx context.Context, request RouteReques
 
 		totalVisitTime += visitDuration
 
-		// Calculate travel time to next location
+		// The leg out of this stop: to the next one, or back to the start on
+		// a round trip. optimizedRoute holds indices into ro.locations, so no
+		// by-ID lookup is needed (and duplicate IDs can't cross wires).
+		next := -1
+		if i < len(optimizedRoute)-1 {
+			next = optimizedRoute[i+1]
+		} else if request.ReturnToStart && len(optimizedRoute) > 1 {
+			next = optimizedRoute[0]
+		}
 		travelToNext := 0
 		travelToNextKm := 0.0
-		if i < len(result)-1 {
-			// Find indices in original locations array
-			currentIdx := ro.findLocationIndex(location.ID)
-			nextIdx := ro.findLocationIndex(result[i+1].ID)
-			if currentIdx != -1 && nextIdx != -1 {
-				travelToNextKm = ro.getDistance(currentIdx, nextIdx)
-				travelToNext = int(math.Ceil(travelToNextKm / 40.0 * 60)) // 40 km/h average
-			}
-		} else if request.ReturnToStart && len(result) > 1 {
-			// Travel time back to start
-			currentIdx := ro.findLocationIndex(location.ID)
-			startIdx := ro.findLocationIndex(result[0].ID)
-			if currentIdx != -1 && startIdx != -1 {
-				travelToNextKm = ro.getDistance(currentIdx, startIdx)
-				travelToNext = int(math.Ceil(travelToNextKm / 40.0 * 60))
+		travelMode := ""
+		if next != -1 {
+			if km, minutes, mode, ok := ro.legTravel(optimizedRoute[i], next); ok {
+				travelToNextKm = km
+				travelToNext = minutes
+				travelMode = mode
+				totalTravelTime += minutes
+				totalTravelKm += km
 			}
 		}
 
@@ -701,25 +807,27 @@ func (ro *RouteOptimizer) OptimizeRoute(ctx context.Context, request RouteReques
 			DepartureTime:    departureTime,
 			TravelToNextMin:  travelToNext,
 			TravelToNextKm:   math.Round(travelToNextKm*100) / 100,
+			TravelToNextMode: travelMode,
 		}
 
 		// Update current time for next location (departure time + travel time)
 		currentTime = currentTime.Add(time.Duration(visitDuration+travelToNext) * time.Minute)
 	}
 
-	totalTripTime := travelTimeMin + totalVisitTime
+	totalTripTime := totalTravelTime + totalVisitTime
 
 	return RouteResponse{
 		OptimizedRoute:     result,
-		TotalDistanceKm:    math.Round(optimizedDistance*100) / 100,
-		TotalTravelTimeMin: travelTimeMin,
+		TotalDistanceKm:    math.Round(totalTravelKm*100) / 100,
+		TotalTravelTimeMin: totalTravelTime,
 		TotalVisitTimeMin:  totalVisitTime,
 		TotalTripTimeMin:   totalTripTime,
 		LocationTimings:    locationTimings,
 		LocationCount:      len(request.Locations),
 		Algorithm:          algorithm,
-		OriginalDistance:   math.Round(originalDistance*100) / 100,
+		OriginalDistance:   math.Round(originalDistance*travelDetourFactor*100) / 100,
 		ImprovementPct:     math.Round(improvementPct*100) / 100,
 		Status:             "success",
-	}
+		Unresolved:         unresolved,
+	}, nil
 }

--- a/src/packages/api/route_optimizer_test.go
+++ b/src/packages/api/route_optimizer_test.go
@@ -26,8 +26,11 @@ func TestOptimizeRoutePreserveOrder(t *testing.T) {
 		},
 	}
 
-	resp := ro.OptimizeRoute(context.Background(), req)
+	resp, err := ro.OptimizeRoute(context.Background(), req)
 
+	if err != nil {
+		t.Fatalf("OptimizeRoute returned error: %v", err)
+	}
 	if resp.Status != "success" {
 		t.Fatalf("expected success, got %q", resp.Status)
 	}


### PR DESCRIPTION
## Summary

Ticket A of the day-travel-times spec (epic artifact `day-travel-times`): the `/optimize-route` contract fixes that un-blank every travel-time surface. Go only; ticket B (client) builds against the contract below.

- **Per-location skip.** A location that fails Places resolution no longer aborts the response. Its legs carry no travel data, and it is reported by name in a new top-level `unresolved` field. One bad place on day 9 can no longer erase day 2's times.
- **No more 200-with-error-stub.** `OptimizeRoute` returns `(RouteResponse, error)`; the handler maps the residual nothing-resolved case to an honest non-200. A 200 **never** carries null `location_timings`/`optimized_route`.
- **Mode-aware heuristic.** Flat 40 km/h is gone. Detour factor 1.3 on haversine; walk at/below 1.5 corrected km at 5 km/h; transit above at 15 km/h; ceil to integer minutes. Each timing entry carries `travel_to_next_mode` — the client icon follows the mode, never a distance constant.

## The contract (ticket B: read this)

**Status codes**

| Case | Code | Body |
| --- | --- | --- |
| Route computed (incl. partial resolution) | 200 | `RouteResponse`, `status: "success"` |
| Malformed request (empty/`>50` locations, missing id, bad lat/lng/start_index) | 400 | `{message, status:"error"}` (unchanged) |
| **No** location resolved, ≥1 failure blames the request (place not found / nothing to look up) | 422 | `{message: "Could not resolve any location: <names>", status:"error"}` |
| **No** location resolved, every failure provider-side (Places outage/quota/missing key — dev :8080 has no key, so all-name-only requests land here) | 503 | same shape |

**Per timing entry** (additive fields only; existing keys unchanged)

- `travel_to_next_minutes` (int, ceil) and `travel_to_next_km` (float, 2dp) — km is now the **detour-corrected** (×1.3) distance, and minutes derive from that same km, so the two always cohere.
- `travel_to_next_mode`: `"walk" | "transit"`. **Present ⇔ the leg was computed.** Absent on the last stop of a one-way route and on any leg touching an unresolved location. Render a connector only where a mode exists.
- Walk ⇔ corrected km ≤ 1.5 (5 km/h); transit above (15 km/h city average incl. waiting). Rounding is honest integer minutes — the "~15 min" presentation shape is the client's.

**Partial resolution**

- `preserve_order: true` (the app's mode): `optimized_route` == input order, **one timing entry per input location, positionally aligned** — the positional zip `timings[i] ↔ locations[i]` survives, so the currently-deployed client keeps correlating correctly during the deploy gap. Unresolved locations keep their entries (location object without `latitude`/`longitude`; legs touching them: 0 min, 0 km, no mode).
- `preserve_order: false`: unresolved locations are **excluded** from `optimized_route`/`location_timings` (a computed order can't honestly place them; nil coords would distort NN/2-opt for everyone else). Invariant in both modes: `location_timings[i]` describes `optimized_route[i]`.
- `unresolved` (top-level, `omitempty`): names of skipped locations (id when nameless). Provider error detail goes to the server log only.
- Totals are per-leg sums: `total_travel_time_minutes` = Σ computed-leg minutes, `total_distance_km` = Σ corrected leg km; `original_distance_km` is corrected onto the same measure; `improvement_percentage` semantics unchanged.

**50-location cap: left as is.** It already 400s with a clear, self-describing message, and ticket B's per-day requests (3–8 places) make it unreachable. No change.

## Testing

- New `route_contract_test.go` — handler-level pins that decode generically (`map[string]any`), which let every pin run **against the pre-fix code and fail behaviorally**: 200-with-null-timings, `HTTP 200 want 422/503`, `leg 0 minutes = 4, want 13` (the spec's Vondelpark 4-min bug), missing `travel_to_next_mode`. Green after the fix.
  - Mode B pin: 1 unresolvable among 4 → 200, 4 positional timings, computed a→b leg, no-mode legs around the bad stop, `unresolved` by name, exactly 1 Places call.
  - All-unresolved → 422; provider-denied → 503.
  - Heuristic: 2.4 km straight → **transit 13 min** (was 4 min car); 1.0 km → **walk 16 min**; 1.2 km straight (1.56 corrected) → transit 7 min, pinning the threshold on corrected km; totals = per-leg sums.
  - Optimize-mode: unresolved excluded from arrays + named.
- Full Go suite vs throwaway Postgres 16 (`postgres:16` container), serial (`-p 1`), exit captured directly (no pipe): **1102 pass / 0 fail / 2 skip** (both pre-existing env-gated skips), `EXIT=0`. `gofmt` and `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790382115&installation_model_id=433099&pr_number=577&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F577&signature=6f16044051de0a205a4b3342b9ad9fdf6131f362f980bcde370ac7be0f0d660c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->