### PR TITLE
test: future-date the trip_airports fixture — #576's fold ate its rows overnight

### DIFF
--- a/src/packages/flutter-app/test/trip_airports_test.dart
+++ b/src/packages/flutter-app/test/trip_airports_test.dart
@@ -90,13 +90,29 @@ BookingTodo _todo(String kind, String key, String title,
     BookingTodo(
         id: key, kind: kind, todoKey: key, title: title, role: role, auto: auto);
 
+String _iso(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+
+// Calendar-day arithmetic, never Duration (the #570 rule): Duration-based day
+// addition lands a calendar day short in the midnight hour across a DST
+// fall-back.
+String _rel(int days) {
+  final now = DateTime.now();
+  return _iso(DateTime(now.year, now.month, now.day + days));
+}
+
 /// A two-city trip whose first and last transport rows are the journey's ends,
 /// labelled by the server with the roles it stores as identity.
+///
+/// Dated in the FUTURE, deliberately: these tests tap row menus, and a trip
+/// whose window has begun folds departed cities to their headers (#576),
+/// hiding the very rows under test. The original fixed 2026-08-24 window aged
+/// into that fold overnight and went red with zero code changes.
 Trip _trip() => Trip(
       id: 't1',
       title: 'Europe',
-      startDate: '2026-08-24',
-      endDate: '2026-08-28',
+      startDate: _rel(30),
+      endDate: _rel(34),
       createdAt: '2026-08-01',
       updatedAt: '2026-08-01',
       originAirport: 'EWR',


### PR DESCRIPTION
## What

`trip_airports_test.dart` is **red on clean main** (`abbcce5`) as of 2026-08-27 — 4 of 8 tests — with zero code changes. Reproduced independently before fixing.

Mechanism: the fixture was fixed at `2026-08-24 → 2026-08-28`. #576 (merged Aug 26, CI green that day) folds departed cities to their headers using `DateTime.now()`. Overnight into Aug 27 the Amsterdam leg became "departed," the fold collapsed the booking rows, and the four tests that tap `more_vert` inside the "EWR → Amsterdam" row found nothing to tap.

Fix: the fixture dates itself 30 days into the future using the DST-safe calendar-day helpers from #570, with a comment recording why future-dating is load-bearing. `8/8 pass` on the same lib code that failed `4/8` — main itself is the fail-against-old evidence.

## The class, scoped but not swept

10+ other test files carry fixed `2026-08-*` dates and will age into date-sensitive behavior (#576's fold, today-mode) one by one. Only this file is red today; the sweep is follow-up work, same shape as #570's.

Test-only change; no lib code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790382597&installation_model_id=433099&pr_number=579&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F579&signature=efc9ec78f855d327f1f0be8c6d007cd2c36e2dd48fc7cefdb31c5540b3dd3293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->