### PR TITLE
fix(map): re-frame the fit on box resize; pay fit room for the control column

### DIFF
--- a/src/packages/flutter-app/lib/widgets/trip_detail/map_band.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_detail/map_band.dart
@@ -37,6 +37,16 @@ const double mapRowMinHeight = 300;
 /// full-screen map is one tap away).
 const double mapBandHeightNarrow = 180;
 
+/// Extra right camera-fit padding for the interactive card, where TripMap's
+/// zoom/reset capsule overlays the bottom-right edge: 8px margin + the 44px
+/// column + 24px marker clearance, minus the 32px base fit padding. At the
+/// map row's ~55% share the column eats enough of the box that a fitted
+/// cluster landed underneath it (the post-#575 off-center report); paying
+/// fit room for it is this card's call, not TripMap's — the full-screen map
+/// keeps the full frame. The non-interactive phone preview draws no
+/// controls, so it passes 0.
+const double mapBandControlColumnInset = 44;
+
 /// The phone layout's band slot: a fixed-height scroll-away preview card in
 /// the page flow. Wide layouts render the map inside the header block's
 /// [TripDetailMapRow] instead — since the map-row redesign nothing above the
@@ -247,8 +257,11 @@ class TripDetailMapBand extends StatelessWidget {
                       .read(homeOverlayChoiceProvider.notifier)
                       .setShown(!showHome),
               fitSignature: focusKey,
-              // Keep fitted markers clear of the chip row overlaid below.
+              // Keep fitted markers clear of the chip row overlaid below and
+              // of the control column on the right (interactive card only —
+              // the preview draws no controls).
               topOverlayInset: hasChips ? MapLegChips.mapTopInset : 0,
+              rightOverlayInset: expandable ? 0 : mapBandControlColumnInset,
               interactive: !expandable,
               emptyLabel: focusKey == null
                   ? l10n.tripNoMappedPlaces

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -30,6 +30,16 @@ const double _pinHitBox = 44;
 /// less than [TripMap.topOverlayInset]'s usual value.
 const double _emptyStateTopInset = 44;
 
+/// Box-width change (px) below which a resize keeps the camera instead of
+/// re-running the fit. Web scrollbars appearing/disappearing move the box
+/// ~15–17px and must never stomp a manual pan/zoom; any real layout change
+/// (a window resize, the map row's flex share settling — the post-#575
+/// off-center bug) moves it well past this. Measured against the width the
+/// current fit was established at, not the previous frame's, so a
+/// continuous window drag accumulates across frames instead of slipping
+/// under the threshold one step at a time.
+const double _refitWidthDelta = 32;
+
 /// One journey endpoint on the trip map: the airport's point plus which travel
 /// legs to draw from it. A null endpoint hides that leg (e.g. a mid-trip
 /// day-chip selection); an entry with both endpoints null should not be passed
@@ -167,6 +177,16 @@ class TripMap extends StatefulWidget {
   /// The default keeps existing call sites unchanged.
   final double topOverlayInset;
 
+  /// Extra right camera-fit padding (px) for the control column overlaying
+  /// the map's bottom-right edge, so fitted markers never land underneath
+  /// it — [topOverlayInset]'s twin for the other overlaid edge. Decided at
+  /// the call site because only the host knows whether the column's share of
+  /// the box is worth paying fit room for: at the ~55% map-row width the
+  /// column eats ~11% of the box (the post-#575 off-center report shows a
+  /// fitted cluster underneath it), while on the full-screen map it is
+  /// negligible. The default keeps existing call sites unchanged.
+  final double rightOverlayInset;
+
   /// False renders a static preview: no gestures and no zoom/reset buttons.
   /// Callers overlay their own tap handler (e.g. tap-to-expand on phones).
   final bool interactive;
@@ -218,6 +238,7 @@ class TripMap extends StatefulWidget {
     this.emptyMessage,
     this.emptyAction,
     this.topOverlayInset = 0,
+    this.rightOverlayInset = 0,
     this.interactive = true,
     this.home = const [],
     this.destinations,
@@ -245,6 +266,12 @@ class _TripMapState extends State<TripMap> {
   /// Width from the previous layout, to catch resizes in [build]'s
   /// LayoutBuilder (they never reach [didUpdateWidget]).
   double? _lastMapWidth;
+
+  /// Width the camera's current fit was established at: the initial layout's
+  /// width, then whatever [_fitToTrip] last saw. A later layout differing
+  /// from it by [_refitWidthDelta] or more means the fit frames a box that
+  /// no longer exists, so the resize branch re-runs it (see [build]).
+  double? _lastFittedWidth;
 
   /// [TripMap.selectedPosition], mirrored into a notifier (synced in
   /// [initState]/[didUpdateWidget]) so pins can render their selected state
@@ -275,10 +302,11 @@ class _TripMapState extends State<TripMap> {
     super.dispose();
   }
 
-  /// Fit padding shared by the initial fit and every re-fit; asymmetric so a
-  /// top overlay (day chips) never covers the topmost fitted marker.
-  EdgeInsets get _fitPadding =>
-      EdgeInsets.fromLTRB(32, 32 + widget.topOverlayInset, 32, 32);
+  /// Fit padding shared by the initial fit and every re-fit; asymmetric so
+  /// an overlaid edge (day chips top, control column right) never covers the
+  /// outermost fitted marker.
+  EdgeInsets get _fitPadding => EdgeInsets.fromLTRB(
+      32, 32 + widget.topOverlayInset, 32 + widget.rightOverlayInset, 32);
 
   static bool _hasCoords(ItineraryItem i) =>
       i.latitude != 0 || i.longitude != 0;
@@ -373,6 +401,10 @@ class _TripMapState extends State<TripMap> {
   /// deferral would not fire without a frame being scheduled).
   void _fitToTrip(List<LatLng> points) {
     if (points.isEmpty) return;
+    // Whatever framing results, it is for the box as laid out now — anchor
+    // the resize threshold to it (covers the signature/content re-fits and
+    // the reset button, not just the resize branch's own re-runs).
+    _lastFittedWidth = _lastMapWidth ?? _lastFittedWidth;
     try {
       if (points.length == 1) {
         _controller.move(points.first, 13);
@@ -579,6 +611,11 @@ class _TripMapState extends State<TripMap> {
     // Destination mode always has ≥2 route points to show, even when a
     // category lens empties the day-filtered items.
     if (mapped.isEmpty && stays.isEmpty && !destMode) {
+      // No live map, no camera: a later content arrival mounts a fresh
+      // FlutterMap whose initialCameraFit frames it at that layout's width,
+      // so widths remembered from a previous mapped phase are meaningless.
+      _lastMapWidth = null;
+      _lastFittedWidth = null;
       return Container(
         color: theme.colorScheme.surfaceContainerHighest,
         // Keep the centered content clear of the day-chip band's *visible*
@@ -731,14 +768,36 @@ class _TripMapState extends State<TripMap> {
       builder: (context, constraints) {
         final minZoom = appMapMinZoomFor(constraints.maxWidth);
 
-        // flutter_map adopts a changed minZoom into the camera's options but
-        // never re-clamps the live zoom, so after a resize nudge the camera
-        // back over the (possibly risen) floor. One move covers both resize
-        // failure modes: moveRaw re-applies clampZoom *and* the camera
-        // constraint, and no-ops when nothing is out of bounds.
+        // The camera never follows the box on its own, so a resize needs a
+        // post-frame correction — which one depends on how big it was:
+        //
+        //  * A meaningful change ([_refitWidthDelta] from the width the fit
+        //    was established at) means the current framing is for a box that
+        //    no longer exists — the post-#575 off-center report: first-fit
+        //    at one width, settle at another, cluster parked under the
+        //    control column. Re-run the fit over the current fit set, the
+        //    same move the fitSignature/content paths make. Skipped while a
+        //    pin is selected: that camera is point-centered, and a resize
+        //    keeps the point centered by itself.
+        //  * Anything smaller (scrollbars, sub-threshold jitter) keeps the
+        //    camera — a manual pan/zoom must survive it — but still needs
+        //    the zoom floor re-clamped: flutter_map adopts a changed
+        //    minZoom into the camera's options without re-clamping the live
+        //    zoom. One move covers both resize failure modes: moveRaw
+        //    re-applies clampZoom *and* the camera constraint, and no-ops
+        //    when nothing is out of bounds. (fitCamera clamps too, so the
+        //    refit branch needs no extra move.)
         if (_lastMapWidth != null && _lastMapWidth != constraints.maxWidth) {
+          final refit = widget.selectedPosition == null &&
+              _lastFittedWidth != null &&
+              (constraints.maxWidth - _lastFittedWidth!).abs() >=
+                  _refitWidthDelta;
           WidgetsBinding.instance.addPostFrameCallback((_) {
             if (!mounted) return;
+            if (refit) {
+              _fitToTrip(fitPoints);
+              return;
+            }
             try {
               final camera = _controller.camera;
               _controller.move(camera.center, math.max(camera.zoom, minZoom));
@@ -746,6 +805,8 @@ class _TripMapState extends State<TripMap> {
           });
         }
         _lastMapWidth = constraints.maxWidth;
+        // First layout: the width initialCameraFit is about to frame.
+        _lastFittedWidth ??= constraints.maxWidth;
 
         // Center on the selected place when one is set (e.g. the map was just
         // (re)built after a list tap); otherwise fit the whole trip.

--- a/src/packages/flutter-app/test/trip_detail_map_row_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_map_row_test.dart
@@ -12,6 +12,7 @@ import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 import 'package:travel_route_planner/services/api_client.dart';
 import 'package:travel_route_planner/services/trip_review_api_service.dart';
 import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/widgets/trip_detail/map_band.dart';
 import 'package:travel_route_planner/widgets/trip_map.dart';
 
 import 'support/l10n_test_app.dart';
@@ -219,6 +220,47 @@ void main() {
       expect(tester.getRect(mapGone).bottom, lessThanOrEqualTo(0),
           reason: 'the full-width map must scroll away too');
     }
+  });
+
+  testWidgets(
+      'wide: the interactive map card pays fit room for the control column',
+      (tester) async {
+    // The zoom/reset capsule overlays the card's bottom-right edge, and at
+    // the row's ~55% share a symmetric fit parked the easternmost cluster
+    // underneath it (the post-#575 off-center report) — the interactive
+    // card passes the asymmetric inset; TripMap itself stays neutral.
+    await _pump(
+      tester,
+      trip: _trip(
+          chat: const TripRefineChat(
+        messageCount: 17,
+        preview: 'Great choice! Go ahead and add it.',
+        updatedAt: '2026-08-25T10:00:00Z',
+      )),
+      review: _lodgingReview,
+      surface: const Size(1200, 800),
+    );
+
+    final map = tester.widget<TripMap>(find.byType(TripMap));
+    expect(map.interactive, isTrue,
+        reason: 'premise: the wide row hosts the interactive card');
+    expect(map.rightOverlayInset, mapBandControlColumnInset);
+  });
+
+  testWidgets('narrow: the control-less preview pays no right inset',
+      (tester) async {
+    await _pump(
+      tester,
+      trip: _trip(),
+      review: _lodgingReview,
+      surface: const Size(375, 800),
+    );
+
+    final map = tester.widget<TripMap>(find.byType(TripMap));
+    expect(map.interactive, isFalse,
+        reason: 'premise: the phone preview absorbs pointers');
+    expect(map.rightOverlayInset, 0,
+        reason: 'no controls render, so no fit room is paid for them');
   });
 
   testWidgets(

--- a/src/packages/flutter-app/test/trip_map_test.dart
+++ b/src/packages/flutter-app/test/trip_map_test.dart
@@ -368,6 +368,103 @@ void main() {
     expect(find.text('12 min'), findsOneWidget);
   });
 
+  group('box resize', () {
+    // Longitude-spread pair (Paris + Vienna at similar latitude) so the fit
+    // is width-limited: a camera kept from a wider box clips both extremes
+    // on the narrower one, which is exactly what the pre-fix code does.
+    final spread = [
+      _item(0, 'Louvre', 48.8606, 2.3376),
+      _item(1, 'Stephansplatz', 48.2085, 16.3731),
+    ];
+    const west = LatLng(48.8606, 2.3376);
+    const east = LatLng(48.2085, 16.3731);
+
+    testWidgets('a meaningful width change re-frames the current fit', (
+      WidgetTester tester,
+    ) async {
+      // One widget instance across pumps: the resize reaches the map only
+      // through its LayoutBuilder, the same shape as a window resize or the
+      // map row's flex share settling (post-#575 off-center report).
+      final map = TripMap(items: spread);
+      await tester.pumpWidget(_hostSized(map, const Size(800, 300)));
+      await tester.pump();
+      expect(_camera(tester).visibleBounds.contains(west), isTrue);
+      expect(_camera(tester).visibleBounds.contains(east), isTrue);
+
+      await tester.pumpWidget(_hostSized(map, const Size(400, 300)));
+      await tester.pump(); // resize laid out; post-frame re-fit scheduled
+      await tester.pump(); // re-fit ran
+
+      final bounds = _camera(tester).visibleBounds;
+      expect(bounds.contains(west), isTrue,
+          reason: 'the fit set must be re-framed for the new box');
+      expect(bounds.contains(east), isTrue,
+          reason: 'the fit set must be re-framed for the new box');
+    });
+
+    testWidgets('a sub-threshold jitter keeps a manual zoom', (
+      WidgetTester tester,
+    ) async {
+      final map = TripMap(items: spread);
+      await tester.pumpWidget(_hostSized(map, const Size(400, 300)));
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.add)); // traveler zooms in
+      await tester.pump();
+      final zoomed = _camera(tester).zoom;
+
+      // Scrollbar-scale width change (17px): the camera must survive — a
+      // re-fit here would stomp the zoom back to the fit level.
+      await tester.pumpWidget(_hostSized(map, const Size(383, 300)));
+      await tester.pump();
+      await tester.pump();
+
+      expect(_camera(tester).zoom, zoomed);
+    });
+
+    testWidgets('a resize while a pin is selected never yanks the camera', (
+      WidgetTester tester,
+    ) async {
+      // Guard rail (passes pre-fix too): the selected camera is
+      // point-centered, and a resize keeps the point centered by itself —
+      // the resize re-fit must leave it alone.
+      final map = TripMap(items: spread, selectedPosition: 0);
+      await tester.pumpWidget(_hostSized(map, const Size(800, 300)));
+      await tester.pump();
+      expect(_camera(tester).zoom, 15);
+
+      await tester.pumpWidget(_hostSized(map, const Size(400, 300)));
+      await tester.pump();
+      await tester.pump();
+
+      final camera = _camera(tester);
+      expect(camera.zoom, 15);
+      expect(camera.center.latitude, closeTo(west.latitude, 1e-4));
+      expect(camera.center.longitude, closeTo(west.longitude, 1e-4));
+    });
+
+    testWidgets('rightOverlayInset keeps the east extreme off the right edge',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        _host(TripMap(items: spread, rightOverlayInset: 44)),
+      );
+      await tester.pump();
+
+      // Width-limited fit: the east extreme sits at the padded edge — base
+      // 32 + the 44 inset from the 400px box's right side — while the west
+      // extreme keeps the symmetric-era 32 (the inset is right-only).
+      final camera = _camera(tester);
+      expect(
+        camera.latLngToScreenOffset(east).dx,
+        lessThanOrEqualTo(400 - 76 + 0.5),
+      );
+      expect(
+        camera.latLngToScreenOffset(west).dx,
+        greaterThanOrEqualTo(32 - 0.5),
+      );
+    });
+  });
+
   testWidgets('topOverlayInset keeps fitted markers below the overlay band', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
Fixes the post-#575 off-center map (epic ticket `map-fit-off-center`): Prague leg focused, city pins hugging the map's right edge with a cluster bubble under the zoom-control column, left two-thirds empty.

## Diagnosis against the running app (before any code change)

Reproduced with a fixture trip shaped like the report (5 central Prague places + 1 airport-adjacent outlier + Vienna leg, Next Step + Continue-chat cards present so the row sits at 55%), host dev stack + headless Chrome CDP at 1440×1000 (map box 480×297, spans x 313–793):

- **Lead 2 confirmed at the settled width.** The Prague-leg fit (which ran at the *correct* 55% width) parked the easternmost cluster bubble at x≈741 — inside the zoom capsule's x-span [741, 785] — exactly the screenshot's "cluster literally under the zoom-control column". `_fitPadding` was 32px symmetric while the capsule (8px margin + 44px column) eats 52px of the right edge — ~11% of the 480px box.
- **Lead 1 confirmed on a surviving-State resize.** Viewport 1440→920 (map box 480→434, wide layout both sides so TripMap's State survives): the camera kept its stale center/zoom — airport pin half-clipped at the left edge, cluster clipped/behind the controls at the right. The LayoutBuilder only re-clamped the zoom floor; nothing re-ran the fit.
- **Load-path nuance (evidence vs. the ranking):** the cards-appear transition (`TripDetailMapRow` swaps `SizedBox` ↔ `IntrinsicHeight`) and narrow↔wide breakpoint crossings **remount** the map subtree, so #575's "full-width for a beat, then 55%" transient self-corrects via a fresh `initialCameraFit` (with a tile flash). The live stale-fit path is any box resize the State survives — window resizes, OS snap, DevTools emulation — plus any future host that resizes without remounting. Both fixes below apply regardless.
- The "left two-thirds empty countryside" is the leg's bimodal bounds (airport outlier stretching west) — data, per the ticket's lead 3, deliberately not "fixed".

## The fix

**1. TripMap re-frames the fit on a real box resize** (`trip_map.dart`). The rule settled: re-run the current fit (post-frame, the same move the fitSignature/content paths make) when the box width moves **≥32px from the width the current fit was established at**, and **never while a pin is selected**.

- The threshold is anchored to a `_lastFittedWidth` (set by the initial layout and by every `_fitToTrip`), not the previous frame's width — a continuous window drag accumulates across frames instead of slipping under the threshold one step at a time.
- Why it can't stomp a manual pan/zoom: web scrollbars appearing/disappearing move the box ~15–17px — those keep the camera and only re-clamp the zoom floor (the pre-existing behavior, still needed since flutter_map adopts a changed minZoom without re-clamping the live zoom). A selected pin's camera is point-centered and survives resizes by itself, so the selection guard skips the refit entirely. Above the threshold the old framing is for a box that no longer exists — re-framing *is* the correct behavior, same as the content-change refit.
- Never-resizing boxes (home band preview, stable-width shared/full-screen mounts) hit the `_lastMapWidth == constraints.maxWidth` early-out — byte-identical behavior. A ≥32px *window* resize on the full-screen/shared maps now re-frames too (same staleness bug there, previously just unreported); with a pin selected they are untouched.
- Empty-state renders null both trackers: a later content arrival mounts a fresh FlutterMap whose `initialCameraFit` frames the new layout, so widths from a previous mapped phase can't leak.

**2. The interactive map-row card pays fit room for the control column** (`map_band.dart` decides; TripMap only gains `rightOverlayInset`, `topOverlayInset`'s twin, default 0). `mapBandControlColumnInset = 44` (8px margin + 44px capsule + 24px marker clearance − 32px base), passed only when the card is interactive — the phone preview draws no controls and passes 0; full-screen/shared/home call sites are unchanged by default.

## Real-app verification (after)

Same fixture, same CDP session, hot-restarted with the fix:

- Prague focus at 1440: easternmost cluster bubble now at x≈700 — clear of the capsule's left edge at 741 (before: at 741, behind the "+" button). Airport outlier unchanged at the 32px west padding.
- 1440→920 resize: the camera re-frames — airport pin fully inside at x≈128 (before: half-clipped at the box edge), cluster at x≈438, clear of the capsule at 477 (before: clipped under it).
- Before/after PNGs archived in the epic artifact: `map-fit-off-center/verification/{05,06,07,08}-*.png` (05/06 before, 07/08 after).

## Tests

- `flutter analyze --no-fatal-infos --fatal-warnings`: exit 0 (3 known route_response.dart infos).
- Full suite: **2027 passed, 4 failed, `EXIT=1`** captured directly (`> log 2>&1; echo EXIT=$?`, no pipe). **All 4 failures are pre-existing on `origin/main`** (abbcce5, the #576 merge): `trip_airports_test.dart` — `_openRowMenu` finds no menu icon on the "EWR → Amsterdam" `BookingTodoRow`. Verified by detached-HEAD A/B: the identical 4 tests fail by name at origin/main with this diff absent (`diff` of the two failure lists is empty). Not touched here — flagged to the integrator; this lane's files and every map test are green.
- New pins:
  - `trip_map_test.dart` "a meaningful width change re-frames the current fit" — **behavioral fail-against-old verified** by stashing lib (param-free probe copy): red with `Expected: true / Actual: <false> — the fit set must be re-framed for the new box`; green with the fix.
  - "a sub-threshold jitter keeps a manual zoom" — pins the no-stomp rule (17px change after a manual zoom-in keeps the zoom).
  - "a resize while a pin is selected never yanks the camera" — guard rail (passes pre-fix too, deliberately: pins the selection guard against future regressions).
  - "rightOverlayInset keeps the east extreme off the right edge" — width-limited fit sits at 32+44 from the right, 32 from the left (asymmetry pinned). Compile-red against old lib (param absent), as new-param pins are.
  - `trip_detail_map_row_test.dart` (the call site's file): interactive wide card passes `mapBandControlColumnInset`, control-less phone preview passes 0. Compile-red against old lib.
- Brand check (`scripts/check.sh`) on both touched lib files: clean.

## Scope notes

- `trip_detail_screen.dart` / `itinerary_tab.dart` untouched (reserved for the day-travel-times hub lane). Only `trip_map.dart`, `map_band.dart`, and the two test files.
- Rectangular fit padding can't express corner exclusion: a *south*-extreme marker in the bottom 52px strip could still sit under the expand/home buttons (as it could pre-#575 at 900px). The tall capsule column — what the report shows — is cleared; called out rather than over-padded (a bottom inset would cost ~17% of the 300px card's height).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790383117&installation_model_id=433099&pr_number=580&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F580&signature=03c401a30c3bdd7d7e9890488bf2621181123960210b9fddb1f94ae179e18e1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->