### PR TITLE
fix(home): the live trip's map band returns — its suppression outlived its reason

### DIFF
--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -211,9 +211,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                 stretch: true,
                 child: LiveTripCard(
                   trip: liveTrip,
-                  // The trips list owns this trip's route band; a second
-                  // one here would starve it (see TripHeroCard.showMap).
-                  showMap: false,
                   // On the Trips tab (not pushed over Home): the Trips nav
                   // item highlights, and `from` sends back here rather than
                   // to a trips list this traveler never opened.

--- a/src/packages/flutter-app/lib/widgets/live_trip_card.dart
+++ b/src/packages/flutter-app/lib/widgets/live_trip_card.dart
@@ -20,17 +20,13 @@ class LiveTripCard extends StatelessWidget {
   final Trip trip;
   final VoidCallback onTap;
 
-  /// Passed through to [TripHeroCard.showMap]. Home passes false: its copy of
-  /// this card and the trips list's are alive at the same time inside
-  /// AppShell's IndexedStack, and two route bands for one trip starve each
-  /// other's tiles until both render blank.
-  final bool showMap;
+  // Both hosts (Home and the trips list, alive together in AppShell's
+  // IndexedStack) render the route band now. Home used to suppress it —
+  // two live flutter_maps for one trip starved each other's tiles until
+  // both went blank — but AppMapVisibilityGate ended that: a hidden tab's
+  // band mounts no map at all, so only the visible host ever holds one.
 
-  const LiveTripCard(
-      {super.key,
-      required this.trip,
-      required this.onTap,
-      this.showMap = true});
+  const LiveTripCard({super.key, required this.trip, required this.onTap});
 
   @override
   Widget build(BuildContext context) {
@@ -52,7 +48,6 @@ class LiveTripCard extends StatelessWidget {
       // "Day 2 of 5" already names the span, so the card's own duration label
       // would be a second total saying the same thing.
       showDuration: false,
-      showMap: showMap,
       leadingMeta: [
         TripHeroCard.heroPill(context, l10n.liveTripStatusLive),
         if (progress != null) TripHeroCard.heroFact(context, progress),

--- a/src/packages/flutter-app/test/home_live_trip_test.dart
+++ b/src/packages/flutter-app/test/home_live_trip_test.dart
@@ -115,14 +115,15 @@ void main() {
     expect(find.text('Day 2 of 3'), findsOneWidget);
   });
 
-  testWidgets('Home\'s live card carries no route band, cache hit or not',
+  testWidgets('Home\'s live card renders the route band on a cache hit',
       (WidgetTester tester) async {
-    // The live card is the ONE card that renders on Home and the trips list
-    // at once (AppShell's IndexedStack keeps both alive), and two flutter_map
-    // instances racing for the same tiles leave BOTH blank — verified in a
-    // browser. The trips list owns this trip's band; suppressing it here is
-    // what makes that one work, so it is pinned rather than left to a
-    // "why is this false?" cleanup.
+    // Inverted pin. Home used to suppress this band: the live card renders
+    // on Home and the trips list at once (AppShell's IndexedStack keeps both
+    // alive), and two flutter_maps racing for one trip's tiles left BOTH
+    // blank — browser-verified at the time. AppMapVisibilityGate killed the
+    // premise: a hidden tab's band mounts no map, so only the visible host
+    // ever holds one, and Home's map came back (it had vanished the day a
+    // trip went live — reported as a lost feature, 2026-08-27).
     SharedPreferences.setMockInitialValues({
       'trip_cache.user-1.trip.t1': jsonEncode({
         'saved_at': '2026-08-01T10:00:00.000',
@@ -160,7 +161,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(LiveTripCard), findsOneWidget);
-    expect(find.byType(TripMapBand), findsNothing);
+    expect(find.byType(TripMapBand), findsOneWidget);
   });
 
   testWidgets('recent-trip tile hides when it is the live trip',


### PR DESCRIPTION
## What

Brian reported the home page's trip widget lost its map background ("must have been an unintentional side effect"). It was neither today's merges nor an accident: Home's live-trip card has passed `showMap: false` since Aug 15, when two live `flutter_map`s for the same trip (Home + trips list, both alive in AppShell's IndexedStack) starved each other's tiles until both rendered blank — browser-verified at the time, and properly pinned by a test.

That premise died on Aug 23: `AppMapVisibilityGate` (perf/map-hardening) means a hidden tab's band mounts **no map at all**, so only the visible host ever holds one. The flag outlived its reason by four days — and its visible effect was the hero's satellite backdrop disappearing **the day the trip went live** (the pre-trip hero shows the band; the live variant suppressed it).

The fix removes the suppression and the now-dead `showMap` param (Home was its only false-passer; the trips list always used the default). Comments at both sites record the history so the next "why is this here?" has an answer.

## Tests

- The suppression pin is **inverted with its history intact**: "Home's live card renders the route band on a cache hit" — fails against the old code (`Found 0 widgets with type TripMapBand`), passes with the fix.
- Affected suites: 21 tests across home_live/trips_list_live/hero_card/travels_band, plus all `home_*`/`continue_*` files — **88 tests, 0 failures**, exits captured directly.
- `flutter analyze --no-fatal-infos --fatal-warnings`: exit 0 (3 pre-existing route_response.dart infos).

The double-mount safety this replaces is owned by `AppMapVisibilityGate` and its own tests from #553.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790386562&installation_model_id=433099&pr_number=581&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F581&signature=e83b2fe199277b0ecd161bb932263ff7a412fa6b6ed2aca78536bc756824b427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->