### PR TITLE
test(trip-detail): de-brittle leg-nights and day-header fixture dates

### DIFF
--- a/src/packages/flutter-app/test/trip_detail_day_header_narrow_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_day_header_narrow_test.dart
@@ -11,6 +11,7 @@ import 'package:travel_route_planner/services/trips_api_service.dart';
 import 'package:travel_route_planner/providers/booking_todos_provider.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/utils/date_formats.dart';
 
 import 'support/l10n_test_app.dart';
 
@@ -52,24 +53,50 @@ ItineraryItem _item(int pos, String name, String city, int day) =>
       city: city,
     );
 
-/// Kraków Aug 29 → Sep 2: one city whose days cross a month boundary, which
-/// is the case the running-month rule exists for. Days 1..5 of the trip map
-/// to Aug 29, 30, 31, Sep 1, Sep 2.
-Trip _monthCrossingTrip() => Trip(
-      id: 't1',
-      title: 'Kraków',
-      startDate: '2026-08-29',
-      endDate: '2026-09-02',
-      createdAt: '2026-08-01',
-      updatedAt: '2026-08-01',
-      items: [
-        _item(0, 'Rynek Główny', 'Kraków', 1),
-        _item(1, 'Wawel', 'Kraków', 2),
-        _item(2, 'Kazimierz', 'Kraków', 3),
-        _item(3, 'Wieliczka', 'Kraków', 4),
-        _item(4, 'Planty', 'Kraków', 5),
-      ],
-    );
+/// One city whose days cross a month boundary — the case the running-month
+/// rule exists for. Days 1..5 map to S..S+4: three days at the tail of one
+/// month, two into the next.
+///
+/// S is computed, never fixed (a fixed window went red the midnight the
+/// calendar walked into it, #579-style): the next month boundary minus three
+/// days, rolled a boundary forward whenever that would NOT leave the trip
+/// safely upcoming — an in-progress fixture renders the live-trip "today"
+/// affordances the narrow assertions below forbid (#576 folds/marks by
+/// DateTime.now()).
+DateTime _monthCrossingStart() {
+  final today = DateUtils.dateOnly(DateTime.now());
+  var firstOfNext = DateTime(today.year, today.month + 1, 1);
+  var s = firstOfNext.subtract(const Duration(days: 3));
+  while (!s.isAfter(today.add(const Duration(days: 2)))) {
+    firstOfNext = DateTime(firstOfNext.year, firstOfNext.month + 1, 1);
+    s = firstOfNext.subtract(const Duration(days: 3));
+  }
+  return s;
+}
+
+String _iso(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+Trip _monthCrossingTrip() {
+  final s = _monthCrossingStart();
+  return Trip(
+    id: 't1',
+    title: 'Kraków',
+    startDate: _iso(s),
+    endDate: _iso(s.add(const Duration(days: 4))),
+    createdAt: '2026-08-01',
+    updatedAt: '2026-08-01',
+    items: [
+      _item(0, 'Rynek Główny', 'Kraków', 1),
+      _item(1, 'Wawel', 'Kraków', 2),
+      _item(2, 'Kazimierz', 'Kraków', 3),
+      _item(3, 'Wieliczka', 'Kraków', 4),
+      _item(4, 'Planty', 'Kraków', 5),
+    ],
+  );
+}
 
 Future<void> _pump(WidgetTester tester, Trip trip, Size size,
     {Locale? locale}) async {
@@ -99,19 +126,22 @@ void main() {
   testWidgets('phone: the month is stated once, then again when it changes',
       (WidgetTester tester) async {
     await _pump(tester, _monthCrossingTrip(), _phone);
+    final s = _monthCrossingStart();
+    String full(int offset) => mmmed().format(s.add(Duration(days: offset)));
+    String short(int offset) => weekdayDay(s.add(Duration(days: offset)));
 
     // First dated day of the group keeps the month...
-    expect(find.text('Sat, Aug 29'), findsOneWidget);
+    expect(find.text(full(0)), findsOneWidget);
     // ...the days that follow inside the same month drop it...
-    expect(find.text('Sun 30'), findsOneWidget);
-    expect(find.text('Mon 31'), findsOneWidget);
-    expect(find.text('Sun, Aug 30'), findsNothing);
-    expect(find.text('Mon, Aug 31'), findsNothing);
+    expect(find.text(short(1)), findsOneWidget);
+    expect(find.text(short(2)), findsOneWidget);
+    expect(find.text(full(1)), findsNothing);
+    expect(find.text(full(2)), findsNothing);
     // ...and the rollover states it again, because "Mon 31 / Tue 1" is
     // genuinely ambiguous and that is exactly where a traveler is checking.
-    expect(find.text('Tue, Sep 1'), findsOneWidget);
-    expect(find.text('Wed 2'), findsOneWidget);
-    expect(find.text('Wed, Sep 2'), findsNothing);
+    expect(find.text(full(3)), findsOneWidget);
+    expect(find.text(short(4)), findsOneWidget);
+    expect(find.text(full(4)), findsNothing);
   });
 
   testWidgets('phone: the day header drops its calendar glyph',
@@ -128,14 +158,14 @@ void main() {
     // width to say the whole thing on every row, and the chip columns that
     // narrow gives up are worth having there.
     await _pump(tester, _monthCrossingTrip(), _desktop);
+    final s = _monthCrossingStart();
 
     expect(find.byIcon(Icons.today), findsWidgets);
-    expect(find.text('Sat, Aug 29'), findsOneWidget);
-    expect(find.text('Sun, Aug 30'), findsOneWidget);
-    expect(find.text('Mon, Aug 31'), findsOneWidget);
-    expect(find.text('Tue, Sep 1'), findsOneWidget);
-    expect(find.text('Wed, Sep 2'), findsOneWidget);
-    expect(find.text('Sun 30'), findsNothing);
+    for (var i = 0; i < 5; i++) {
+      expect(find.text(mmmed().format(s.add(Duration(days: i)))),
+          findsOneWidget);
+    }
+    expect(find.text(weekdayDay(s.add(const Duration(days: 1)))), findsNothing);
   });
 
   testWidgets('phone: the short label localizes', (WidgetTester tester) async {
@@ -147,7 +177,8 @@ void main() {
     await _pump(tester, _monthCrossingTrip(), _phone,
         locale: const Locale('es'));
 
-    expect(find.text('Sun 30'), findsOneWidget);
+    expect(find.text(weekdayDay(_monthCrossingStart().add(const Duration(days: 1)))),
+        findsOneWidget);
   });
 
   testWidgets('an undated trip still falls back to "Day N"',

--- a/src/packages/flutter-app/test/trip_detail_leg_nights_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_leg_nights_test.dart
@@ -13,6 +13,7 @@ import 'package:travel_route_planner/services/trips_api_service.dart';
 import 'package:travel_route_planner/providers/booking_todos_provider.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/utils/date_formats.dart';
 
 import 'support/chip_finders.dart';
 import 'support/city_groups.dart';
@@ -86,15 +87,38 @@ Future<void> _pump(WidgetTester tester, Trip trip, {Locale? locale}) async {
   await tester.pumpAndSettle();
 }
 
-/// Prague Aug 24 – Aug 27 (3 nights), Kraków Aug 27 – Sep 1 (5 nights) —
-/// the canonical example the feature was asked for. Day numbers encode each
-/// city's ARRIVAL: a leg runs until the next leg's first item day
-/// (specs/leg-departure-dates), with the last leg carried to the trip end.
+/// Calendar-day anchor for every fixture trip below: tonight + 7, so the
+/// trip is always UPCOMING. The fixed Aug/Sep 2026 windows went red the week
+/// the calendar crossed them (#579 all over again: #576 folds departed cities
+/// by DateTime.now(), and a city whose days are all past renders nothing like
+/// the expanded group these tests pin). Offsets from the anchor keep each
+/// fixture's original leg structure — day numbers and night counts are
+/// unchanged, only the absolute dates moved.
+final _anchor = DateUtils.dateOnly(DateTime.now()).add(const Duration(days: 7));
+
+String _iso(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+/// The city-header chip's range text for a leg running [from]–[to] days after
+/// [_anchor] — computed with the same helper the chip renders through.
+String _range(int from, int to) => formatShortRange(
+    _anchor.add(Duration(days: from)), _anchor.add(Duration(days: to)));
+
+/// A bare single-date chip (the zero-night squeeze), [offset] days after
+/// [_anchor].
+String _chipDate(int offset) => mmmd().format(_anchor.add(Duration(days: offset)));
+
+/// Prague day 1, Kraków day 4 — the canonical example the feature was asked
+/// for. Day numbers encode each city's ARRIVAL: a leg runs until the next
+/// leg's first item day (specs/leg-departure-dates), with the last leg
+/// carried to the trip end. Prague gets 3 nights, Kraków 5.
 Trip _pragueKrakowTrip() => Trip(
       id: 't1',
       title: 'Big Summer',
-      startDate: '2026-08-24',
-      endDate: '2026-09-01',
+      startDate: _iso(_anchor),
+      endDate: _iso(_anchor.add(const Duration(days: 8))),
       createdAt: '2026-08-01',
       updatedAt: '2026-08-01',
       items: [
@@ -103,8 +127,8 @@ Trip _pragueKrakowTrip() => Trip(
       ],
     );
 
-/// [_pragueKrakowTrip] with Kraków run through Sep 12 (16 nights) plus Vienna
-/// Sep 12 – Sep 14 (2 nights). Kraków's chip is the strict widest (26 glyphs
+/// [_pragueKrakowTrip] with Kraków run to day 20 (16 nights) plus Vienna for
+/// the trip's last 2 nights. Kraków's chip is the strict widest (26 glyphs
 /// under the uniform-advance test font vs 25 for the others), so a regression
 /// to per-row intrinsic widths misaligns its row against the other two, and
 /// the shared width here is one glyph wider than [_pragueKrakowTrip]'s — the
@@ -112,8 +136,8 @@ Trip _pragueKrakowTrip() => Trip(
 Trip _threeCityTrip() => Trip(
       id: 't1',
       title: 'Big Summer',
-      startDate: '2026-08-24',
-      endDate: '2026-09-14',
+      startDate: _iso(_anchor),
+      endDate: _iso(_anchor.add(const Duration(days: 21))),
       createdAt: '2026-08-01',
       updatedAt: '2026-08-01',
       items: [
@@ -123,14 +147,14 @@ Trip _threeCityTrip() => Trip(
       ],
     );
 
-/// Quito shares Galápagos's Sep 6 arrival — a genuine zero-night leg
+/// Quito shares Galápagos's day-6 arrival — a genuine zero-night leg
 /// (specs/leg-departure-dates) with a bare single-date chip between two
 /// counted legs.
 Trip _squeezeTrip() => Trip(
       id: 't1',
       title: 'Squeeze',
-      startDate: '2026-09-01',
-      endDate: '2026-09-07',
+      startDate: _iso(_anchor),
+      endDate: _iso(_anchor.add(const Duration(days: 6))),
       createdAt: '2026-08-01',
       updatedAt: '2026-08-01',
       items: [
@@ -144,12 +168,13 @@ Trip _squeezeTrip() => Trip(
 
 /// Prague plus an item whose locality can't be resolved — the 'Other places'
 /// group, whose header has no refine sparkle to align against. Its day-4
-/// arrival ends Prague at Aug 27 and the last-leg anchor runs it to Sep 1.
+/// arrival ends Prague at day 3 and the last-leg anchor runs it to the trip
+/// end (5 nights).
 Trip _pragueMysteryTrip() => Trip(
       id: 't1',
       title: 'Big Summer',
-      startDate: '2026-08-24',
-      endDate: '2026-09-01',
+      startDate: _iso(_anchor),
+      endDate: _iso(_anchor.add(const Duration(days: 8))),
       createdAt: '2026-08-01',
       updatedAt: '2026-08-01',
       items: [
@@ -190,9 +215,9 @@ void main() {
     await _pump(tester, _pragueKrakowTrip());
 
     // Scoped per row: the count must sit in the SAME chip as its range.
-    expect(chipTextIn('Prague', 'Aug 24 – Aug 27'), findsOneWidget);
+    expect(chipTextIn('Prague', _range(0, 3)), findsOneWidget);
     expect(chipTextIn('Prague', '· 3 nights'), findsOneWidget);
-    expect(chipTextIn('Kraków', 'Aug 27 – Sep 1'), findsOneWidget);
+    expect(chipTextIn('Kraków', _range(3, 8)), findsOneWidget);
     expect(chipTextIn('Kraków', '· 5 nights'), findsOneWidget);
   });
 
@@ -202,9 +227,9 @@ void main() {
     // Galápagos leg still gets its counter.
     await _pump(tester, _squeezeTrip());
 
-    expect(chipTextIn('Quito', 'Sep 6'), findsOneWidget);
+    expect(chipTextIn('Quito', _chipDate(5)), findsOneWidget);
     expect(find.textContaining('0 nights'), findsNothing);
-    expect(chipTextIn('Galápagos', 'Sep 6 – Sep 7'), findsOneWidget);
+    expect(chipTextIn('Galápagos', _range(5, 6)), findsOneWidget);
     expect(chipTextIn('Galápagos', '· 1 night'), findsOneWidget);
   });
 
@@ -262,7 +287,7 @@ void main() {
     // The dates still belong to Prague's header (chipTextIn scopes to the
     // row), but they now sit on a SECOND line under the name.
     final name = cityHeaderLabel('Prague');
-    final dates = chipTextIn('Prague', 'Aug 24 – Aug 27');
+    final dates = chipTextIn('Prague', _range(0, 3));
     expect(dates, findsOneWidget);
     expect(chipTextIn('Prague', '· 3 nights'), findsOneWidget);
     expect(
@@ -335,11 +360,11 @@ void main() {
         moreOrLessEquals(iconX, epsilon: 0.1),
         reason: 'calendar icons must form a column');
 
-    final rangeX = tester.getTopLeft(find.text('Aug 24 – Aug 27')).dx;
-    expect(tester.getTopLeft(find.text('Aug 27 – Sep 12')).dx,
+    final rangeX = tester.getTopLeft(find.text(_range(0, 3))).dx;
+    expect(tester.getTopLeft(find.text(_range(3, 19))).dx,
         moreOrLessEquals(rangeX, epsilon: 0.1),
         reason: 'range starts must form a column');
-    expect(tester.getTopLeft(find.text('Sep 12 – Sep 14')).dx,
+    expect(tester.getTopLeft(find.text(_range(19, 21))).dx,
         moreOrLessEquals(rangeX, epsilon: 0.1),
         reason: 'range starts must form a column');
 


### PR DESCRIPTION
## What

`trip_detail_leg_nights_test.dart` and `trip_detail_day_header_narrow_test.dart` went red on main this week — same disease as #579: fixed-date trip fixtures the calendar walked past.

- The leg-nights fixtures were fixed at Aug 24 – Sep 14, 2026. Once Prague's days all departed, #576's fold-by-`DateTime.now()` collapsed exactly the city groups whose expanded headers the chip-column tests pin (`expand_more` chevrons and date chips gone).
- The day-header fixture started `2026-08-29`; the midnight the trip became "starts today," the live-trip affordances (`Icons.today`) appeared in the narrow layout that forbids a calendar glyph.

Surfaced by #583's full-suite run, which reproduced all three failures identically at the base revision before opening.

## Fix

Fixture-date arithmetic only — no `lib/` changes, no assertion semantics changed:

- Leg-nights trips anchor at tonight + 7 (always upcoming; day numbers, leg structure, and night counts untouched).
- The month-crossing trip takes the next month boundary minus three days, rolled a boundary forward whenever that wouldn't stay safely upcoming — the 3-days-before / 2-days-after rollover structure is the point of that file.
- Expected chip ranges and day-header labels are computed with the same `date_formats` helpers production renders through (`formatShortRange` / `mmmd` / `mmmed` / `weekdayDay`), so the assertions track whatever absolute dates the anchor lands on.

## Verification

- Both files red at `origin/main` (`148b2b6`) today, green on this branch — fail-against-old is inherent.
- All 58 `test/trip_detail_*_test.dart` files green (two serial batches, `EXIT=0` each).
- `flutter analyze --no-fatal-infos --fatal-warnings` on both files: no issues.

Unblocks #583's suite going fully green once both land.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790780166&installation_model_id=433099&pr_number=584&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F584&signature=47a063407e4530e08f3b73c99251115fd430f9f8d16b3ad3ecbd4396af4e32ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->