### PR TITLE
copy(quiz): the gender step's subtitle states the why, drops the skip-narration

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -330,7 +330,7 @@
   "quizBaggageTitle": "What do you fly with?",
   "quizBaggageSubtitle": "So the fares you're shown already include your bag fees.",
   "quizGenderTitle": "What's your gender?",
-  "quizGenderSubtitle": "Optional — it helps with packing suggestions and safety tips. Skip it if you'd rather not say.",
+  "quizGenderSubtitle": "Optional — used to tailor packing suggestions and safety tips.",
   "quizTripsTitle": "Any trips you're dreaming about?",
   "quizTripsSubtitle": "Places, seasons, occasions — the planner will keep them in mind.",
   "quizTripsHint": "e.g. Japan for cherry blossom season, a Greek island hop next summer…",

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -249,7 +249,7 @@
   "quizBaggageTitle": "¿Con qué equipaje vuelas?",
   "quizBaggageSubtitle": "Así las tarifas que te mostremos ya incluirán el coste de tu equipaje.",
   "quizGenderTitle": "¿Cuál es tu género?",
-  "quizGenderSubtitle": "Opcional: ayuda con sugerencias de equipaje y consejos de seguridad. Sáltalo si prefieres no decirlo.",
+  "quizGenderSubtitle": "Opcional: se usa para adaptar las sugerencias de equipaje y los consejos de seguridad.",
   "quizTripsTitle": "¿Sueñas con algún viaje?",
   "quizTripsSubtitle": "Lugares, épocas del año, ocasiones: el planificador los tendrá en cuenta.",
   "quizTripsHint": "p. ej. Japón en temporada de cerezos en flor, saltar de isla en isla por Grecia el próximo verano…",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -1595,7 +1595,7 @@ abstract class AppLocalizations {
   /// No description provided for @quizGenderSubtitle.
   ///
   /// In en, this message translates to:
-  /// **'Optional — it helps with packing suggestions and safety tips. Skip it if you\'d rather not say.'**
+  /// **'Optional — used to tailor packing suggestions and safety tips.'**
   String get quizGenderSubtitle;
 
   /// No description provided for @quizTripsTitle.

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -803,7 +803,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get quizGenderSubtitle =>
-      'Optional — it helps with packing suggestions and safety tips. Skip it if you\'d rather not say.';
+      'Optional — used to tailor packing suggestions and safety tips.';
 
   @override
   String get quizTripsTitle => 'Any trips you\'re dreaming about?';

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -812,7 +812,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get quizGenderSubtitle =>
-      'Opcional: ayuda con sugerencias de equipaje y consejos de seguridad. Sáltalo si prefieres no decirlo.';
+      'Opcional: se usa para adaptar las sugerencias de equipaje y los consejos de seguridad.';
 
   @override
   String get quizTripsTitle => '¿Sueñas con algún viaje?';


### PR DESCRIPTION
## Summary
- One-commit follow-up to #587, which merged while this rider was in flight: the quiz gender step's subtitle becomes **"Optional — used to tailor packing suggestions and safety tips."** (es: "Opcional: se usa para adaptar las sugerencias de equipaje y los consejos de seguridad.") — states the why, drops the "Skip it if you'd rather not say" mechanics-narration the Next button already conveys.
- Generated l10n files edited by construction (values only, wrap shapes unchanged), per this machine's Homebrew-formatter lesson from #587's own CI saga.

## Testing
- Analyzer clean; the quiz test file green (it pins the step title, not the subtitle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791507660&installation_model_id=433099&pr_number=588&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F588&signature=b41ef529e6ab83956fd82e6ceb75def30273c6eaadc25e6e9c4b72aeff326839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->